### PR TITLE
[Encryption] Improve cipher detection

### DIFF
--- a/src/encrypt.h
+++ b/src/encrypt.h
@@ -19,6 +19,7 @@
 #define BUF_SIZE 512
 #define BLOCK_SIZE 32
 
+#define CIPHER_NUM          14
 #define NONE                -1 
 #define TABLE               0
 #define RC4                 1


### PR DESCRIPTION
The original way to detect cipher by name is a little complicated and unsafe, since the function will raise a segment fault when the required cipher not available in OpenSSL library. This pull request adds some code to check the result of `EVP_get_cipherbyname` to avoid this issue.
