### PR TITLE
Fix latest 1.4.2 build for win32 (MinGW)

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -7,6 +7,10 @@
 #include <stdlib.h>
 #include "cache.h"
 
+#ifdef __MINGW32__
+#include "win32.h"
+#endif
+
 /** Creates a new cache object
 
     @param dst

--- a/src/include.h
+++ b/src/include.h
@@ -8,6 +8,6 @@ int udprelay_init(const char *server_host, const char *server_port,
 #ifdef UDPRELAY_REMOTE
              asyncns_t *asyncns,
 #endif
-             int method, int timeout, const char *interface);
+             int method, int timeout, const char *iface);
 
 #endif // _INCLUDE_H

--- a/src/udprelay.c
+++ b/src/udprelay.c
@@ -754,7 +754,7 @@ int udprelay_init(const char *server_host, const char *server_port,
 #ifdef UDPRELAY_REMOTE
              asyncns_t *asyncns,
 #endif
-             int method, int timeout, const char *interface)
+             int method, int timeout, const char *iface)
 {
 
     // Inilitialize ev loop
@@ -778,7 +778,7 @@ int udprelay_init(const char *server_host, const char *server_port,
     struct server_ctx *server_ctx = new_server_ctx(serverfd);
     server_ctx->timeout = timeout;
     server_ctx->method = method;
-    server_ctx->iface = interface;
+    server_ctx->iface = iface;
     server_ctx->conn_cache = conn_cache;
 #ifdef UDPRELAY_LOCAL
     server_ctx->remote_host = remote_host;

--- a/src/win32.h
+++ b/src/win32.h
@@ -1,6 +1,10 @@
 #ifndef _WIN32_H
 #define _WIN32_H
 
+#ifdef _WIN32_WINNT
+#undef _WIN32_WINNT
+#endif
+
 #define _WIN32_WINNT 0x0501
 
 #include <winsock2.h>
@@ -29,5 +33,7 @@ void winsock_init(void);
 void winsock_cleanup(void);
 void ss_error(const char *s);
 size_t strnlen(const char *s, size_t maxlen);
+int setnonblocking(int fd);
+const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
 
 #endif


### PR DESCRIPTION
As the latest build treats warnings as errors, the win32 port cannot be built successfully. Here is the patch to make it work again.
