### PR TITLE
Support for Apple's CommonCrypto API

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -18,11 +18,17 @@
 /* Define to 1 if you have the <arpa/inet.h> header file. */
 #undef HAVE_ARPA_INET_H
 
+/* Define to 1 if you have the `CCCryptorCreateWithMode' function. */
+#undef HAVE_CCCRYPTORCREATEWITHMODE
+
 /* Define to 1 if you have the `clock_gettime' function. */
 #undef HAVE_CLOCK_GETTIME
 
 /* Define to 1 to use the syscall interface for clock_gettime */
 #undef HAVE_CLOCK_SYSCALL
+
+/* Define to 1 if you have the <CommonCrypto/CommonCrypto.h> header file. */
+#undef HAVE_COMMONCRYPTO_COMMONCRYPTO_H
 
 /* Define to 1 if you have the declaration of `inet_ntop', and to 0 if you
    don't. */
@@ -275,6 +281,9 @@
 
 /* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
 #undef TIME_WITH_SYS_TIME
+
+/* Use Apple CommonCrypto library */
+#undef USE_CRYPTO_APPLECC
 
 /* Use OpenSSL library */
 #undef USE_CRYPTO_OPENSSL

--- a/configure
+++ b/configure
@@ -752,6 +752,7 @@ with_openssl_lib
 with_polarssl
 with_polarssl_include
 with_polarssl_lib
+enable_applecc
 enable_assert
 enable_largefile
 '
@@ -1391,6 +1392,7 @@ Optional Features:
   --enable-fast-install[=PKGS]
                           optimize for fast installation [default=yes]
   --disable-libtool-lock  avoid locking (might break parallel builds)
+  --enable-applecc        enable Apple CommonCrypto API support
   --disable-assert        turn off assertions
   --disable-largefile     omit support for large files
 
@@ -12977,6 +12979,46 @@ $as_echo "#define USE_CRYPTO_POLARSSL 1" >>confdefs.h
 
     ;;
 esac
+
+# Check whether --enable-applecc was given.
+if test "${enable_applecc+set}" = set; then :
+  enableval=$enable_applecc;
+    for ac_header in CommonCrypto/CommonCrypto.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "CommonCrypto/CommonCrypto.h" "ac_cv_header_CommonCrypto_CommonCrypto_h" "$ac_includes_default"
+if test "x$ac_cv_header_CommonCrypto_CommonCrypto_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_COMMONCRYPTO_COMMONCRYPTO_H 1
+_ACEOF
+
+else
+  as_fn_error $? "CommonCrypto header files not found." "$LINENO" 5; break
+
+fi
+
+done
+
+    for ac_func in CCCryptorCreateWithMode
+do :
+  ac_fn_c_check_func "$LINENO" "CCCryptorCreateWithMode" "ac_cv_func_CCCryptorCreateWithMode"
+if test "x$ac_cv_func_CCCryptorCreateWithMode" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_CCCRYPTORCREATEWITHMODE 1
+_ACEOF
+
+else
+  as_fn_error $? "CommonCrypto API needs OS X (>= 10.7) and iOS (>= 5.0)." "$LINENO" 5; break
+
+fi
+done
+
+
+$as_echo "#define USE_CRYPTO_APPLECC 1" >>confdefs.h
+
+
+
+fi
+
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for C/C++ restrict keyword" >&5
 $as_echo_n "checking for C/C++ restrict keyword... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,21 @@ case "${with_crypto_library}" in
     ;;
 esac
 
+dnl Checks for Apple CommonCrypto API
+AC_ARG_ENABLE(applecc,
+  AS_HELP_STRING([--enable-applecc], [enable Apple CommonCrypto API support]),
+  [
+    AC_CHECK_HEADERS(CommonCrypto/CommonCrypto.h,
+      [],
+      [AC_MSG_ERROR([CommonCrypto header files not found.]); break]
+    )
+    AC_CHECK_FUNCS([CCCryptorCreateWithMode], ,
+      [AC_MSG_ERROR([CommonCrypto API needs OS X (>= 10.7) and iOS (>= 5.0).]); break]
+    )
+    AC_DEFINE([USE_CRYPTO_APPLECC], [1], [Use Apple CommonCrypto library])
+  ]
+)
+
 dnl Checks for inet_ntop
 ss_FUNC_INET_NTOP
 

--- a/src/encrypt.h
+++ b/src/encrypt.h
@@ -25,7 +25,7 @@
 
 #include <openssl/evp.h>
 typedef EVP_CIPHER cipher_kt_t;
-typedef EVP_CIPHER_CTX cipher_ctx_t;
+typedef EVP_CIPHER_CTX cipher_evp_t;
 typedef EVP_MD digest_type_t;
 #define MAX_KEY_LENGTH EVP_MAX_KEY_LENGTH
 #define MAX_IV_LENGTH EVP_MAX_IV_LENGTH
@@ -36,13 +36,43 @@ typedef EVP_MD digest_type_t;
 #include <polarssl/cipher.h>
 #include <polarssl/md.h>
 typedef cipher_info_t cipher_kt_t;
-typedef cipher_context_t cipher_ctx_t;
+typedef cipher_context_t cipher_evp_t;
 typedef md_info_t digest_type_t;
 #define MAX_KEY_LENGTH 64
 #define MAX_IV_LENGTH POLARSSL_MAX_IV_LENGTH
 #define MAX_MD_SIZE POLARSSL_MD_MAX_SIZE
 
 #endif
+
+#ifdef USE_CRYPTO_APPLECC
+
+#include <CommonCrypto/CommonCrypto.h>
+
+#define kCCAlgorithmInvalid UINT32_MAX
+#define kCCContextValid 0
+#define kCCContextInvalid -1
+
+typedef struct {
+    CCCryptorRef cryptor;
+    int valid;
+    CCOperation encrypt;
+    CCAlgorithm cipher;
+    CCMode mode;
+    CCPadding padding;
+    uint8_t iv[MAX_IV_LENGTH];
+    uint8_t key[MAX_KEY_LENGTH];
+    size_t iv_len;
+    size_t key_len;
+} cipher_cc_t;
+
+#endif
+
+typedef struct {
+    cipher_evp_t evp;
+#ifdef USE_CRYPTO_APPLECC
+    cipher_cc_t cc;
+#endif
+} cipher_ctx_t;
 
 #ifdef HAVE_STDINT_H
 #include <stdint.h>


### PR DESCRIPTION
Instead of OpenSSL, Apple provides CommonCrypto API as a native crypto API for Darwin because [Apple insists OpenSSL cannot provide a _stable_ API](https://developer.apple.com/library/mac/documentation/security/conceptual/cryptoservices/GeneralPurposeCrypto/GeneralPurposeCrypto.html). CommonCrypto API is actually a wrapper of the _CoreCrypto_ module, which has **hardware accelerated** crypto implementation (especially AES) for Mac and iOS devices.

So, this patch attempts to use CommonCrypto as a crypto backend in order to achieve potential better performance on Darwin platforms. But currently OpenSSL or PolarSSL library is _still needed_ for several functions missing in CommonCrypto. 

Use `--enable-applecc` to enable the CommonCrypto API support. Patch is tested to work on OS X 10.9.2.
