### PR TITLE
fix problem when  ss_decrypt_all return NULL , server crash

### DIFF
--- a/src/udprelay.c
+++ b/src/udprelay.c
@@ -504,6 +504,13 @@ static void remote_recv_cb (EV_P_ ev_io *w, int revents)
 
 #ifdef UDPRELAY_LOCAL
     buf = ss_decrypt_all(BUF_SIZE, buf, &buf_len, server_ctx->method);
+    if (buf == NULL){
+        if (verbose)
+        {
+            ERROR("udprelay_server_ss_decrypt_all");
+        }
+        goto CLEAN_UP;
+    }
 
     int len = parse_udprealy_header(buf, buf_len, NULL, NULL);
     if (len == 0 || len != addr_header_len)
@@ -580,6 +587,13 @@ static void server_recv_cb (EV_P_ ev_io *w, int revents)
 
 #ifdef UDPRELAY_REMOTE
     buf = ss_decrypt_all(BUF_SIZE, buf, &buf_len, server_ctx->method);
+    if (buf == NULL){
+        if (verbose)
+        {
+            ERROR("udprelay_server_ss_decrypt_all");
+        }
+        goto CLEAN_UP;
+    }
 #endif
 
 #ifdef UDPRELAY_LOCAL


### PR DESCRIPTION
server config

```
{
  "server" : "0.0.0.0",
  "server_port" : 6351,
  "password" : "somepassword",
  "method": "aes-256-cfb",
  "timeout": 600
}
```

run server with `./ss-server  -c config.json -u`

send some udp packets to the server 

```
echo -n "he" | nc -4u -q1 localhost 6351
```

server crashes with segment fault. 

```
(gdb) backtrace 
#0  0x00000000004078d9 in parse_udprealy_header (buf=0x0, buf_len=2, host=0x7fffffffe230 "", port=0x7fffffffe1f0 "")
    at udprelay.c:93
#1  0x0000000000408d4c in server_recv_cb (loop=0x621720 <default_loop_struct>, w=0x628320, revents=1) at udprelay.c:658
#2  0x00000000004137b2 in ev_invoke_pending (loop=0x621720 <default_loop_struct>) at ev.c:2994
#3  0x000000000041468c in ev_run (loop=0x621720 <default_loop_struct>, flags=0) at ev.c:3394
#4  0x000000000040f498 in main (argc=4, argv=0x7fffffffe658) at server.c:1064
```

It seems   when  server_recv_cb  is not checking  ss_decrypt_all return value , when it returns NULL , the server crash.   
