### PR TITLE
On Windows, read CRLF ending file exist some problem that tested by MinG...

### DIFF
--- a/src/jconf.c
+++ b/src/jconf.c
@@ -102,7 +102,7 @@ jconf_t *read_jconf(const char* file)
     char *buf;
     json_value *obj;
 
-    FILE *f = fopen(file, "r");
+    FILE *f = fopen(file, "rb");
     if (f == NULL) FATAL("Invalid config path.");
 
     fseek(f, 0, SEEK_END);


### PR DESCRIPTION
...W and VS2008.

1)open CRLF ending file in text mode
2)
    fseek(f, 0, SEEK_END);
    long pos = ftell(f); // return the file total byte
    fseek(f, 0, SEEK_SET);
3)
    int nread = fread(buf, pos, 1, f); // always return 0 to nread
    int nread = fread(buf, 1, pos, f); // return readed byte with CRLF converted to LF. it means pos - nread = CRLF's count.
