### PR TITLE
build shared library by default

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,9 @@
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 
+override_dh_auto_configure:
+	dh_auto_configure -- \
+        --enable-shared
 
 %:
 	dh $@ 


### PR DESCRIPTION
build shared library on Debian distros by default. (sorry for the typo on commit log)
