### PR TITLE
add fflush stderr on Windows.

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -98,7 +98,8 @@ extern FILE * logfile;
         time_t now = time(NULL);                                              \
         char timestr[20];                                                     \
         strftime(timestr, 20, TIME_FORMAT, localtime(&now));                  \
-        fprintf(stderr, " %s INFO: " format "\n", timestr, ## __VA_ARGS__); } \
+        fprintf(stderr, " %s INFO: " format "\n", timestr, ## __VA_ARGS__);   \
+        fflush(stderr); }                                                     \
     while (0)
 
 #define LOGE(format, ...)                                                      \
@@ -106,7 +107,8 @@ extern FILE * logfile;
         time_t now = time(NULL);                                               \
         char timestr[20];                                                      \
         strftime(timestr, 20, TIME_FORMAT, localtime(&now));                   \
-        fprintf(stderr, " %s ERROR: " format "\n", timestr, ## __VA_ARGS__); } \
+        fprintf(stderr, " %s ERROR: " format "\n", timestr, ## __VA_ARGS__);   \
+        fflush(stderr); }                                                      \
     while (0)
 
 #else


### PR DESCRIPTION
unfortunately, Windows will buffer stderr if it's not executed in `cmd.exe`,
which will cause unpleasant buffered log output. adding fflush(stderr) will
solve this aged issue.
