### PR TITLE
completely rename as shadowsocks-libev.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then,
 
 ``` bash
 sudo apt-get update
-sudo apt-get install shadowsocks
+sudo apt-get install shadowsocks-libev
 ```
 
 #### Build package from source
@@ -63,17 +63,17 @@ cd shadowsocks-libev
 sudo apt-get install build-essential autoconf libtool libssl-dev gawk debhelper
 sudo dpkg-buildpackage
 cd ..
-sudo dpkg -i shadowsocks*.deb
+sudo dpkg -i shadowsocks-libev*.deb
 ```
 
 #### Configure and start the service
 
 ```
 # Edit the configuration
-sudo vim /etc/shadowsocks/config.json
+sudo vim /etc/shadowsocks-libev/config.json
 
 # Start the service
-sudo /etc/init.d/shadowsocks start
+sudo /etc/init.d/shadowsocks-libev start
 ```
 
 ### CentOS
@@ -92,7 +92,7 @@ Compile and install,
 make install
 ```
 
-Then copy this [init script](rpm/SOURCES/etc/init.d/shadowsocks) to `/etc/init.d/`.
+Then copy this [init script](rpm/SOURCES/etc/init.d/shadowsocks-libev) to `/etc/init.d/`.
 
 ### Linux
 

--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,5 @@ Vcs-Browser: https://github.com/madeye/shadowsocks-libev
 Package: shadowsocks-libev
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Conflicts: shadowsocks
 Description: A lightweight secured scoks5 proxy. 
     Shadowsocks-libev is a lightweight secured scoks5 proxy for embedded devices and low end boxes.

--- a/debian/install
+++ b/debian/install
@@ -1,1 +1,1 @@
-debian/config.json  /etc/shadowsocks
+debian/config.json  /etc/shadowsocks-libev

--- a/debian/shadowsocks-libev.default
+++ b/debian/shadowsocks-libev.default
@@ -10,7 +10,7 @@
 START=yes
 
 # Configuration file
-CONFFILE="/etc/shadowsocks/config.json"
+CONFFILE="/etc/shadowsocks-libev/config.json"
 
 # Extra command line arguments
 DAEMON_ARGS=""

--- a/rpm/SOURCES/etc/init.d/shadowsocks-libev
+++ b/rpm/SOURCES/etc/init.d/shadowsocks-libev
@@ -28,7 +28,7 @@ DAEMON=/usr/local/bin/ss-server
 
 # Path to the configuration file.
 #
-CONF=/etc/shadowsocks/config.json
+CONF=/etc/shadowsocks-libev/config.json
 
 #USER="nobody"
 #GROUP="nobody"

--- a/shadowsocks-libev.8
+++ b/shadowsocks-libev.8
@@ -128,7 +128,7 @@ Enable ACL (Access Control List).
 
 .SH SEE ALSO
 .BR iptables (8),
-/etc/shadowsocks/config.json
+/etc/shadowsocks-libev/config.json
 .br
 .SH AUTHOR
 shadowsocks was created by clowwindy <clowwindy42@gmail.com> and


### PR DESCRIPTION
it's not conflicted with shadowsocks-python now. users can install both python and libev
ports of shaowsocks now. but they should migrate their old configuration file from
/etc/shadowsocks/config.json to /etc/shadowsocks-libev/config.json

Since this would break the name-related stuff, it'd better be included in next minor version (aka 1.6.0)
