### PR TITLE
patch mingw x86 libev compile error.

### DIFF
--- a/libev/ev.h
+++ b/libev/ev.h
@@ -157,6 +157,13 @@ typedef double ev_tstamp;
 # ifdef _WIN32
 #  include <time.h>
 #  include <sys/types.h>
+#  ifndef HAVE_STRUCT_TIMESPEC
+#   define HAVE_STRUCT_TIMESPEC 1
+      struct timespec {
+        long tv_sec;
+        long tv_nsec;
+      };
+#  endif /* HAVE_STRUCT_TIMESPEC */
 # endif
 # include <sys/stat.h>
 #endif


### PR DESCRIPTION
patch mingw x86 compile error about "struct timespec", also should make sure pthread library name is "libpthreads.a".
