### PR TITLE
add the default port for tunnel

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -753,6 +753,10 @@ int main(int argc, char **argv)
     // parse tunnel addr
     parse_addr(tunnel_addr_str, &tunnel_addr);
 
+    if (tunnel_addr.port == NULL) {
+        tunnel_addr.port = "53";
+    }
+
 #ifdef __MINGW32__
     winsock_init();
 #else


### PR DESCRIPTION
ss-tunnel 大多数时候是用于做 DNS 查询，最近遇到两次在指定 `-L` 参数时忘记写 port 的： 
https://v2ex.com/t/149245#r_1539902 
aa65535/openwrt-shadowsocks#16 

觉得有必要在 port 为空时有个默认值(53)。
