### PR TITLE
Dockerfile for Shadowsocks-libev

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,21 +9,23 @@ ENV CONFIGFILE $CONFIGDIR/shadowsocks.json
 ENV PORT 8388
 
 # Set up building environment
-RUN apt-get update
-RUN apt-get install -y $DEPENDENCIES
+RUN apt-get update && \
+    apt-get install -y $DEPENDENCIES && \
+    apt-get clean
 
 # Get the latest code, build and install
 WORKDIR $BASEDIR
 RUN git clone https://github.com/shadowsocks/shadowsocks-libev.git
 WORKDIR $BASEDIR/shadowsocks-libev
-RUN ./configure
-RUN make
-RUN make install
+RUN ./configure && \
+    make && \
+    make install
 
 # Tear down building environment and delete git repository
 WORKDIR $BASEDIR
 RUN rm -rf $BASEDIR/shadowsocks-libev
-RUN apt-get --purge autoremove -y $DEPENDENCIES
+RUN apt-get --purge autoremove -y $DEPENDENCIES && \
+    apt-get clean
 
 # Config file can be in a separated container
 VOLUME ["$CONFIGDIR"]
@@ -33,4 +35,5 @@ ADD shadowsocks.json $CONFIGFILE
 EXPOSE $PORT
 
 # Override the host and port in the config file.
-CMD ss-server --fast-open -c $CONFIGFILE -s 0.0.0.0 -p $PORT
+ENTRYPOINT /entrypoint.sh
+CMD --help

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:latest
+
+MAINTAINER Sah Lee <contact@leesah.name>
+
+ENV DEPENDENCIES git-core build-essential autoconf libtool libssl-dev
+ENV BASEDIR /tmp
+ENV CONFIGDIR /etc/shadowsocks
+ENV CONFIGFILE $CONFIGDIR/shadowsocks.json
+ENV PORT 8388
+
+# Set up building environment
+RUN apt-get update
+RUN apt-get install -y $DEPENDENCIES
+
+# Get the latest code, build and install
+WORKDIR $BASEDIR
+RUN git clone https://github.com/shadowsocks/shadowsocks-libev.git
+WORKDIR $BASEDIR/shadowsocks-libev
+RUN ./configure
+RUN make
+RUN make install
+
+# Tear down building environment and delete git repository
+WORKDIR $BASEDIR
+RUN rm -rf $BASEDIR/shadowsocks-libev
+RUN apt-get --purge autoremove -y $DEPENDENCIES
+
+# Config file can be in a separated container
+VOLUME ["$CONFIGDIR"]
+ADD shadowsocks.json $CONFIGFILE
+
+# Port in the config file won't take affect. Instead we'll use 8388.
+EXPOSE $PORT
+
+# Override the host and port in the config file.
+CMD ss-server --fast-open -c $CONFIGFILE -s 0.0.0.0 -p $PORT

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,65 @@
+# Shadowsocks Dockerized
+
+## What is Shadowsocks
+
+A secure socks5 proxy designed to protect your Internet traffic.
+
+See http://shadowsocks.org/
+
+## What is Docker
+
+An open platform for distributed applications for developers and sysadmins.
+
+See https://www.docker.com/
+
+## How to use this image
+
+### Start the daemon for the firt time
+
+Pull the image.
+
+```bash
+$ docker pull leesah/shadowsocks-libev
+```
+
+Create a data container and edit the configuration file.
+
+```bash
+$ docker run --name shadowsocks-data leesah/shadowsocks-libev /bin/true
+$ docker run --interactive --tty --rm --volumes-from shadowsocks-data leesah/shadowsocks-libev vi /etc/shadowsocks/shadowsocks.json
+```
+
+Start the daemon container.
+
+```bash
+$ docker run --name shadowsocks-app --detach --publish 58388:8388 --volumes-from shadowsocks-data leesah/shadowsocks-libev
+```
+
+### Stop the daemon
+
+```bash
+$ docker stop shadowsocks-app
+```
+
+### Start a stopped daemon
+
+```bash
+$ docker start shadowsocks-app
+```
+
+### Upgrade
+
+COMING SOON
+
+### Use in CoreOS
+
+COMING SOON
+
+### Use with `fig`
+
+COMING SOON
+
+## References
+
+* [Shadowsocks - Servers](http://shadowsocks.org/en/download/servers.html)
+* [shadowsocks-libev](https://github.com/shadowsocks/shadowsocks-libev/blob/master/README.md)

--- a/docker/shadowsocks.json
+++ b/docker/shadowsocks.json
@@ -1,0 +1,5 @@
+{
+    "password":"Change Me!",
+    "timeout":120,
+    "method":"aes-256-cfb"
+}


### PR DESCRIPTION
This is a `Dockerfile` which builds a `Shadowsocks-libev` image based on the official `Ubuntu` image, shipped with a default `json` config file a `README.md` describing the usage.

Automated build can now be found at https://registry.hub.docker.com/u/leesah/shadowsocks-libev/

Built image is verified on a CoreOS VPS hosted by [Vultr](https://www.vultr.com/).