### PR TITLE
Refine nameserver settings

### DIFF
--- a/src/jconf.c
+++ b/src/jconf.c
@@ -168,6 +168,8 @@ jconf_t *read_jconf(const char * file)
                 conf.fast_open = value->u.boolean;
             } else if (strcmp(name, "nofile") == 0) {
                 conf.nofile = value->u.integer;
+            } else if (strcmp(name, "nameserver") == 0) {
+                conf.nameserver = to_string(value);
             }
         }
     } else {

--- a/src/jconf.h
+++ b/src/jconf.h
@@ -43,6 +43,7 @@ typedef struct {
     char *timeout;
     int fast_open;
     int nofile;
+    char *nameserver;
 } jconf_t;
 
 jconf_t *read_jconf(const char * file);

--- a/src/server.c
+++ b/src/server.c
@@ -971,8 +971,7 @@ int main(int argc, char **argv)
     const char *server_port = NULL;
 
     char * nameservers[MAX_DNS_NUM + 1];
-    int nameserver_num = 1;
-    nameservers[0] = "8.8.8.8";
+    int nameserver_num = 0;
 
     int option_index = 0;
     static struct option long_options[] =
@@ -1078,6 +1077,9 @@ int main(int argc, char **argv)
             set_nofile(nofile);
         }
 #endif
+        if (conf->nameserver != NULL) {
+            nameservers[nameserver_num++] = conf->nameserver;
+        }
     }
 
     if (server_num == 0 || server_port == NULL || password == NULL) {
@@ -1122,6 +1124,9 @@ int main(int argc, char **argv)
     struct ev_loop *loop = EV_DEFAULT;
 
     // setup udns
+    if (nameserver_num == 0) {
+        nameservers[nameserver_num++] = "8.8.8.8";
+    }
     resolv_init(loop, nameservers, nameserver_num);
 
     // inilitialize listen context
@@ -1143,6 +1148,10 @@ int main(int argc, char **argv)
         }
         setnonblocking(listenfd);
         LOGI("server listening at port %s", server_port);
+
+        for (int i = 0; i < nameserver_num; i++) {
+            LOGI("using nameserver: %s", nameservers[i]);
+        }
 
         struct listen_ctx *listen_ctx = &listen_ctx_list[index];
 


### PR DESCRIPTION
Changes:

* Use the `nameserver` in the configuration file if any.
* Use Google Public DNS only if the user does not nominate a nameserver.

Rationale:

Servers usually have _caching_ DNS resolvers like `dnsmasq` and `unbound`. It will be waste of resources if every query is sent to Google Public DNS.

Issues:

* Currently, only one `nameserver` can be specified in the configuration file.
* I am not sure what your intent is when you fall back to the system-wide configuration if the second parameter (`nameservers`) of `resolv.c:resolv_init` is `NULL` even if it can never be (because Google Public DNS is added anyway).
* I am too lazy to update supporting documents like `README`...