### PR TITLE
Update server.c

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -167,6 +167,9 @@ int create_and_bind(const char *host, const char *port)
         }
 
         int opt = 1;
+
+        setsockopt(listen_sock, IPPROTO_IPV6, IPV6_V6ONLY, &opt, sizeof(opt));
+        
         setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
 #ifdef SO_NOSIGPIPE
         setsockopt(listen_sock, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof(opt));


### PR DESCRIPTION
Fix multi addr bind: 
example ./ss-server -s 0 -s :: 
 2015-01-21 07:28:09 ERROR: bind: Address already in use
 2015-01-21 07:28:09 ERROR: Could not bind
 2015-01-21 07:28:09 ERROR: bind() error


The reason the address is already in use is because on many IPv6 networking stacks, by default an IPv6 socket will listen to both IPv4 and IPv6 at the same time. IPv4 connections will be handled transparently and mapped to a subset of the IPv6 space(http://tools.ietf.org/html/rfc4291#section-2.5.5.2). However, this means you cannot bind to an IPv6 socket on the same port as an IPv4 socket without changing the settings on the IPv6 socket. 
Linux leaves it off by default.