### PR TITLE
fixed config.json compatibility issue

### DIFF
--- a/src/jconf.c
+++ b/src/jconf.c
@@ -165,7 +165,7 @@ jconf_t *read_jconf(const char * file)
                 }
             } else if (strcmp(name, "server_port") == 0) {
                 conf.remote_port = to_string(value);
-            } else if (strcmp(name, "local") == 0) {
+            } else if (strcmp(name, "local_address") == 0) {
                 conf.local_addr = to_string(value);
             } else if (strcmp(name, "local_port") == 0) {
                 conf.local_port = to_string(value);


### PR DESCRIPTION
in wiki https://github.com/shadowsocks/shadowsocks/wiki/Configuration-via-Config-File the format of config is
```
{
    "server":"my_server_ip",
    "server_port":8388,
    "local_address": "127.0.0.1",
    "local_port":1080,
    "password":"mypassword",
    "timeout":300,
    "method":"aes-256-cfb",
    "fast_open": false
}
```
i think it's better to compatible with that.