### PR TITLE
Fix wrong typo in init.d script

### DIFF
--- a/debian/shadowsocks-libev.init
+++ b/debian/shadowsocks-libev.init
@@ -7,7 +7,7 @@
 # Default-Stop:      0 1 6
 # Short-Description: lightweight secured scoks5 proxy
 # Description:       Shadowsocks-libev is a lightweight secured 
-#                    scoks5 proxy for embedded devices and low end boxes.
+#                    socks5 proxy for embedded devices and low end boxes.
 #                    
 ### END INIT INFO
 


### PR DESCRIPTION
wrong spelling of 'socks5' in shadowsocks-libev.init