### PR TITLE
Fix typo in init.d script under rpm directory

### DIFF
--- a/rpm/SOURCES/etc/init.d/shadowsocks-libev
+++ b/rpm/SOURCES/etc/init.d/shadowsocks-libev
@@ -6,7 +6,7 @@
 #====================================================================
 # Run level information:
 # chkconfig: 2345 99 99
-# Description: lightweight secured scoks5 proxy
+# Description: lightweight secured socks5 proxy
 # processname: ss-server
 # Author: Max Lv <max.c.lv@gmail.com>;
 # Run "/sbin/chkconfig --add shadowsocks" to add the Run levels.


### PR DESCRIPTION
here is also a wrong spelling...