### PR TITLE
When user running ss-local but not input any argument, ss-local will try...

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -37,6 +37,8 @@
 
 #endif
 
+#define DEFAULT_CONF_PATH "/etc/shadowsocks/config.json"
+
 #ifndef SOL_TCP
 #define SOL_TCP IPPROTO_TCP
 #endif

--- a/src/local.c
+++ b/src/local.c
@@ -963,6 +963,11 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    if (argc == 1) {
+        if (conf_path == NULL) {
+            conf_path = DEFAULT_CONF_PATH;
+        }
+    }
     if (conf_path != NULL) {
         jconf_t *conf = read_jconf(conf_path);
         if (remote_num == 0) {


### PR DESCRIPTION
... to use ./config(if exist).

 bettter way.

change default config path as /etc/shadowsocks/config.json

When user running ss-local but not input any argument, ss-local will try to use ./config(if exist).

Fixed the indent