### PR TITLE
Change 'scoks' to 'socks'

### DIFF
--- a/debian/shadowsocks-libev.init
+++ b/debian/shadowsocks-libev.init
@@ -5,7 +5,7 @@
 # Required-Stop:     $remote_fs
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: lightweight secured scoks5 proxy
+# Short-Description: lightweight secured socks5 proxy
 # Description:       Shadowsocks-libev is a lightweight secured 
 #                    socks5 proxy for embedded devices and low end boxes.
 #                    

--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -39,7 +39,7 @@ define Package/shadowsocks-libev-polarssl
 endef
 
 define Package/shadowsocks-libev/description
-Shadowsocks-libev is a lightweight secured scoks5 proxy for embedded devices and low end boxes.
+Shadowsocks-libev is a lightweight secured socks5 proxy for embedded devices and low end boxes.
 endef
 
 Package/shadowsocks-libev-polarssl/description=$(Package/shadowsocks-libev/description)

--- a/shadowsocks-libev.8
+++ b/shadowsocks-libev.8
@@ -27,7 +27,7 @@
 
 .TH SHADOWSOCKS-LIBEV 8 "January 7, 2015"
 .SH NAME
-shadowsocks-libev \- a lightweight and secure scoks5 proxy
+shadowsocks-libev \- a lightweight and secure socks5 proxy
 
 .SH SYNOPSIS
 \*(Lo|\*(Re|\*(Se

--- a/shadowsocks-libev.pc.in
+++ b/shadowsocks-libev.pc.in
@@ -4,7 +4,7 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: shadowsocks-libev
-Description: a lightweight secured scoks5
+Description: a lightweight secured socks5 proxy
 URL: http://shadowsocks.org
 Version: @VERSION@
 Requires:


### PR DESCRIPTION
There are several words written as 'scoks5' in the repo and I believe that they should be 'socks5'.