### PR TITLE
Fixes OSX 10.11 Beta build failed

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -79,6 +79,10 @@
 #define BUF_SIZE 2048
 #endif
 
+#ifndef MSG_FASTOPEN
+#define MSG_FASTOPEN   0x20000000
+#endif
+
 int verbose = 0;
 #ifdef ANDROID
 int vpn = 0;

--- a/src/server.c
+++ b/src/server.c
@@ -79,6 +79,10 @@
 #define SSMAXCONN 1024
 #endif
 
+#ifndef MSG_FASTOPEN
+#define MSG_FASTOPEN   0x20000000
+#endif
+
 static void signal_cb(EV_P_ ev_signal *w, int revents);
 static void accept_cb(EV_P_ ev_io *w, int revents);
 static void server_send_cb(EV_P_ ev_io *w, int revents);


### PR DESCRIPTION
solve `MSG_FASTOPEN` undeclared identifier

> see #357

Finally, pass build on OSX 10.11 Beta(DP5)!

Thanks @madeye 's HELP.