### PR TITLE
Fix mistake in pkgconfig .pc file

### DIFF
--- a/shadowsocks-libev.pc.in
+++ b/shadowsocks-libev.pc.in
@@ -8,5 +8,5 @@ Description: a lightweight secured socks5 proxy
 URL: http://shadowsocks.org
 Version: @VERSION@
 Requires:
-Libs: -I${includedir}
-Cflags: -L${libdir} -lshadowsocks -lcrypto
+Cflags: -I${includedir}
+Libs: -L${libdir} -lshadowsocks -lcrypto


### PR DESCRIPTION
Currently shadowsocks-libev.pc.in seems to be invalid and was warned by lintian when trying to build deb package:

    E: shadowsocks-libev: pkg-config-bad-directive usr/lib/x86_64-linux-gnu/pkgconfig/shadowsocks-libev.pc Cflags: -L${libdir} -lshadowsocks -lcrypto

So I corrected it and now it seems to be working.