### PR TITLE
Add service templates and a option to build against system shared libs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,8 @@
+if USE_SYSTEM_SHARED_LIB
+SUBDIRS = libcork libipset src
+else
 SUBDIRS = libsodium libcork libipset libudns libev src
+endif
 
 ACLOCAL_AMFLAGS = -I m4
 man_MANS = man/shadowsocks-libev.8 man/ss-server.1 man/ss-local.1 man/ss-redir.1\

--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,18 @@ AC_DISABLE_STATIC
 AC_DISABLE_SHARED
 LT_INIT([dlopen])
 
+dnl Checks for using shared libraries from system
+AC_ARG_ENABLE(
+  [system-shared-lib],
+  AS_HELP_STRING([--enable-system-shared-lib], [build against shared libraries when possible]),
+  [
+    case "${enableval}" in
+      yes) enable_system_shared_lib=true ;;
+      no) enable_system_shared_lib=false ;;
+      *) AC_MSG_ERROR([bad value ${enableval} for --enable-system-shared-lib]) ;;
+    esac], [enable_system_shared_lib=false])
+AM_CONDITIONAL([USE_SYSTEM_SHARED_LIB], [test x$enable_system_shared_lib = xtrue])
+
 dnl Checks for crypto library
 AC_ARG_WITH(
   [crypto-library],

--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -1,15 +1,16 @@
 shadowsocks-libev for Debian
 ----------------------
 
-The Debian package has added systemd support. By default, the dpkg installer
-will enable initscripts if the OS is using sysvinit, and systemd service unit
-file if the OS is using systemd. This is done automatically.
+The Debian package has added systemd support. A default server service which
+reads the default configuration in /etc/default/shadowsocks-libev is installed
+and enabled by default, plus some other service templates placed in
+/lib/systemd/system, which can be used by users later.
 
 Another problem is that shadowsocks-libev is licensed under GPLv3+. This will
 conflict with OpenSSL License when linked against OpenSSL library. As a
 result, this package faces licensing problem. Use it at your own risk.
 
- -- Boyuan Yang <073plan@gmail.com>  Fri, 11 Sep 2015 19:08:30 +0800
+ -- Boyuan Yang <073plan@gmail.com>  Wed, 14 Oct 2015 09:18:50 +0800
 
 (No special notes.)
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -13,6 +13,57 @@ Copyright: 2013-2015 Max Lv <max.c.lv@gmail.com>
            2015, Boyuan Yang <073plan@gmail.com>
 License: GPL-3+
 
+Files: libcork/Makefile.am libipset/Makefile.am libipset/bdd/Makefile.am libipset/map/Makefile.am libipset/set/Makefile.am
+Copyright: 2005-2008 Lennart Poettering
+License: LGPL-2.1+
+ This package is free software; you can redistribute it and/or modify
+ it under the terms of the GNU Lesser General Public License as
+ published by the Free Software Foundation, either version 2.1 of the
+ License, or (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful, but
+ WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+ .
+ You should have received a copy of the GNU Lesser General Public
+ License along with libasyncns. If not, see
+ <http://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the complete text of the GNU Lesser General Public
+ License version 2.1 can be found in "/usr/share/common-licenses/LGPL-2.1".
+
+Files: libcork/* libipset/*
+Copyright: 2011-2013, RedJack, LLC.
+License: BSD-3-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ .
+ Redistributions of source code must retain the above copyright
+ notice, this list of conditions and the following disclaimer.
+ .
+ Redistributions in binary form must reproduce the above copyright
+ notice, this list of conditions and the following disclaimer in
+ the documentation and/or other materials provided with the
+ distribution.
+ .
+ Neither the name of RedJack Software, LLC nor the names of its
+ contributors may be used to endorse or promote products derived
+ from this software without specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 License: GPL-3+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/debian/libshadowsocks1.symbols
+++ b/debian/libshadowsocks1.symbols
@@ -1,8 +1,8 @@
 libshadowsocks.so.1 libshadowsocks1 #MINVER#
  ERROR@Base 2.3.1
  FATAL@Base 2.3.1
- #MISSING: 2.4.0-1 _crypto_stream_salsa20@Base 2.3.1
- #MISSING: 2.4.0-1 _crypto_stream_salsa20_xor_ic@Base 2.3.1
+ _crypto_stream_salsa20@Base 2.4.0
+ _crypto_stream_salsa20_xor_ic@Base 2.4.0
  _dns_format_code@Base 2.3.1
  acl_contains_ip@Base 2.3.1
  bytes_to_key@Base 2.3.1
@@ -601,16 +601,16 @@ libshadowsocks.so.1 libshadowsocks1 #MINVER#
  ss_itoa@Base 2.3.1
  ss_onetimeauth@Base 2.3.1
  ss_onetimeauth_verify@Base 2.3.1
- ss_sha1@Base 2.4.0-1
- ss_sha1_finish@Base 2.4.0-1
- ss_sha1_hmac@Base 2.4.0-1
- ss_sha1_hmac_finish@Base 2.4.0-1
- ss_sha1_hmac_reset@Base 2.4.0-1
- ss_sha1_hmac_starts@Base 2.4.0-1
- ss_sha1_hmac_update@Base 2.4.0-1
- ss_sha1_process@Base 2.4.0-1
- ss_sha1_starts@Base 2.4.0-1
- ss_sha1_update@Base 2.4.0-1
+ ss_sha1@Base 2.4.0
+ ss_sha1_finish@Base 2.4.0
+ ss_sha1_hmac@Base 2.4.0
+ ss_sha1_hmac_finish@Base 2.4.0
+ ss_sha1_hmac_reset@Base 2.4.0
+ ss_sha1_hmac_starts@Base 2.4.0
+ ss_sha1_hmac_update@Base 2.4.0
+ ss_sha1_process@Base 2.4.0
+ ss_sha1_starts@Base 2.4.0
+ ss_sha1_update@Base 2.4.0
  ss_strndup@Base 2.3.1
  start_ss_local_server@Base 2.3.1
  udns_jraninit@Base 2.3.1

--- a/debian/rules
+++ b/debian/rules
@@ -27,5 +27,12 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
         --enable-shared
 
+override_dh_installinit:
+	dh_installinit
+	dh_installinit --no-start --name=shadowsocks-libev-server@
+	dh_installinit --no-start --name=shadowsocks-libev-tunnel@
+	dh_installinit --no-start --name=shadowsocks-libev-redir@
+	dh_installinit --no-start --name=shadowsocks-libev-local@
+
 %:
 	dh $@  --with systemd

--- a/debian/shadowsocks-libev-local@.service
+++ b/debian/shadowsocks-libev-local@.service
@@ -1,0 +1,23 @@
+#  This file is part of shadowsocks-libev.
+#
+#  Shadowsocks-libev is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This is a template unit file. Users may copy and rename the file into
+#  config directories to make new service instances. See systemd.unit(5)
+#  for details.
+
+[Unit]
+Description=Shadowsocks-Libev Custom Client Service for %I
+After=network.target
+
+[Service]
+Type=simple
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+ExecStart=/usr/bin/ss-local -c /etc/shadowsocks-libev/%i.json
+
+[Install]
+WantedBy=multi-user.target
+

--- a/debian/shadowsocks-libev-redir@.service
+++ b/debian/shadowsocks-libev-redir@.service
@@ -1,0 +1,23 @@
+#  This file is part of shadowsocks-libev.
+#
+#  Shadowsocks-libev is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This is a template unit file. Users may copy and rename the file into
+#  config directories to make new service instances. See systemd.unit(5)
+#  for details.
+
+[Unit]
+Description=Shadowsocks-Libev Custom Client Service Redir Mode for %I
+After=network.target
+
+[Service]
+Type=simple
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+ExecStart=/usr/bin/ss-redir -c /etc/shadowsocks-libev/%i.json
+
+[Install]
+WantedBy=multi-user.target
+

--- a/debian/shadowsocks-libev-server@.service
+++ b/debian/shadowsocks-libev-server@.service
@@ -1,0 +1,23 @@
+#  This file is part of shadowsocks-libev.
+#
+#  Shadowsocks-libev is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This is a template unit file. Users may copy and rename the file into
+#  config directories to make new service instances. See systemd.unit(5)
+#  for details.
+
+[Unit]
+Description=Shadowsocks-Libev Custom Server Service for %I
+After=network.target
+
+[Service]
+Type=simple
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+ExecStart=/usr/bin/ss-server -c /etc/shadowsocks-libev/%i.json
+
+[Install]
+WantedBy=multi-user.target
+

--- a/debian/shadowsocks-libev-tunnel@.service
+++ b/debian/shadowsocks-libev-tunnel@.service
@@ -1,0 +1,23 @@
+#  This file is part of shadowsocks-libev.
+#
+#  Shadowsocks-libev is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  This is a template unit file. Users may copy and rename the file into
+#  config directories to make new service instances. See systemd.unit(5)
+#  for details.
+
+[Unit]
+Description=Shadowsocks-Libev Custom Client Service Tunnel Mode for %I
+After=network.target
+
+[Service]
+Type=simple
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+ExecStart=/usr/bin/ss-tunnel -c /etc/shadowsocks-libev/%i.json
+
+[Install]
+WantedBy=multi-user.target
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,17 +2,23 @@ VERSION_INFO = 1:0:0
 
 AM_CFLAGS = -g -O2 -Wall -Werror -Wno-deprecated-declarations -fno-strict-aliasing -std=gnu99 -D_GNU_SOURCE
 AM_CFLAGS += $(PTHREAD_CFLAGS)
+if !USE_SYSTEM_SHARED_LIB
 AM_CFLAGS += -I$(top_srcdir)/libev
 AM_CFLAGS += -I$(top_srcdir)/libudns
+AM_CFLAGS += -I$(top_srcdir)/libsodium/src/libsodium/include
+endif
 AM_CFLAGS += -I$(top_srcdir)/libipset/include
 AM_CFLAGS += -I$(top_srcdir)/libcork/include
-AM_CFLAGS += -I$(top_srcdir)/libsodium/src/libsodium/include
 
-SS_COMMON_LIBS = $(top_builddir)/libev/libev.la \
-				 $(top_builddir)/libipset/libipset.la \
-				 $(top_builddir)/libcork/libcork.la \
-				 $(top_builddir)/libsodium/src/libsodium/libsodium.la \
-				 $(INET_NTOP_LIB)
+SS_COMMON_LIBS = $(top_builddir)/libipset/libipset.la \
+                 $(top_builddir)/libcork/libcork.la \
+                 $(INET_NTOP_LIB)
+if USE_SYSTEM_SHARED_LIB
+SS_COMMON_LIBS += -lev -lsodium -lm
+else
+SS_COMMON_LIBS += $(top_builddir)/libev/libev.la \
+                  $(top_builddir)/libsodium/src/libsodium/libsodium.la
+endif
 
 bin_PROGRAMS = ss-local ss-tunnel
 if !BUILD_WINCOMPAT
@@ -61,9 +67,15 @@ ss_local_LDADD = $(SS_COMMON_LIBS)
 ss_tunnel_LDADD = $(SS_COMMON_LIBS)
 ss_server_LDADD = $(SS_COMMON_LIBS)
 ss_manager_LDADD = $(SS_COMMON_LIBS)
+if USE_SYSTEM_SHARED_LIB
+ss_local_LDADD += -ludns
+ss_tunnel_LDADD += -ludns
+ss_server_LDADD += -ludns
+else
 ss_local_LDADD += $(top_builddir)/libudns/libudns.la
 ss_tunnel_LDADD += $(top_builddir)/libudns/libudns.la
 ss_server_LDADD += $(top_builddir)/libudns/libudns.la
+endif
 
 ss_local_CFLAGS = $(AM_CFLAGS) -DUDPRELAY_LOCAL
 ss_tunnel_CFLAGS = $(AM_CFLAGS) -DUDPRELAY_LOCAL -DUDPRELAY_TUNNEL
@@ -87,7 +99,11 @@ ss_redir_SOURCES = utils.c \
                    redir.c
 ss_redir_CFLAGS = $(AM_CFLAGS) -DUDPRELAY_REDIR -DUDPRELAY_LOCAL
 ss_redir_LDADD = $(SS_COMMON_LIBS)
+if USE_SYSTEM_SHARED_LIB
+ss_redir_LDADD += -ludns
+else
 ss_redir_LDADD += $(top_builddir)/libudns/libudns.la
+endif
 endif
 
 lib_LTLIBRARIES = libshadowsocks.la


### PR DESCRIPTION
* Added several systemd service templates for `ss-server`, `ss-redir`, `ss-local` and `ss-tunnel` from downstream Archlinux AUR, which may benefit advanced users to cooperate better with systemd.

* Added a configure-time option into autotools scripts which allows user to use system-proviced `libsodium`, `libev` and `libudns` instead of the static-linked one. Considering that `shadowsocks-libev` is used widely in lower-end devices which requires binaries to be build with static libraries, this option is still made optional and only for advanced users or downstream Linux distribution package maintainers.

* I didn't find `libcork` and the so-called `libipset` in Debian and most of the distributions, so they are kept and some copyright information was added into `debian/copyright`.