### PR TITLE
don't configure libsodium when using system libs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,7 +245,9 @@ else
     LIBS="$LIBS $PTHREAD_LIBS"
 fi
 
-AC_CONFIG_SUBDIRS([libsodium])
+AM_COND_IF([USE_SYSTEM_SHARED_LIB],
+  [],
+  [AC_CONFIG_SUBDIRS([libsodium])])
 
 AC_CONFIG_FILES([ shadowsocks-libev.pc
                  Makefile


### PR DESCRIPTION
Don't configure libsodium when using system libs since it would be a waste of time.

P.S: Please update configure scripts using `autoreconf`, thanks.
@madeye 