### PR TITLE
fix two error

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -301,14 +301,11 @@ static void server_recv_cb(EV_P_ ev_io *w, int revents)
                     endpoints.sae_dstaddr = (struct sockaddr*)&(remote->addr);
                     endpoints.sae_dstaddrlen = remote->addr_len;
 
-                    struct iovec iov;
-                    iov.iov_base = remote->buf->array;
-                    iov.iov_len = remote->buf->len;
-                    size_t len;
-                    int s = connectx(remote->fd, &endpoints, SAE_ASSOCID_ANY, CONNECT_DATA_IDEMPOTENT,
-                            &iov, 1, &len, NULL);
+                    int s = connectx(remote->fd, &endpoints, SAE_ASSOCID_ANY,
+                            CONNECT_RESUME_ON_READ_WRITE | CONNECT_DATA_IDEMPOTENT,
+                            NULL, 0, NULL, NULL);
                     if (s == 0) {
-                        s = len;
+                        s = send(remote->fd, remote->buf->array, remote->buf->len, 0);
                     }
 #else
                     int s = sendto(remote->fd, remote->buf->array, remote->buf->len, MSG_FASTOPEN,

--- a/src/server.c
+++ b/src/server.c
@@ -446,7 +446,7 @@ static remote_t *connect_to_remote(struct addrinfo *res,
             } else {
                 ERROR("sendto");
             }
-        } else if (s < server->buf->len) {
+        } else if (s <= server->buf->len) {
             server->buf->idx += s;
             server->buf->len -= s;
         } else {


### PR DESCRIPTION
1. The error fixed by  e7a1d1e3337708567d3b8edee34471d90e9dbfe6 also exist in server.c
2. Use connectx to send first package will return error EINPROGRESS in local.c, but the same code work in server.c

However, with this commit, ss-local with fastopen on Darwin still can't work completely. HTTP request can get right reponse, but the data sent in first package will be sent again.
I think there still be error like `if (s < server->buf->len)`

I'm sorry for insufficient test in last pull request.