### PR TITLE
Enable TCP keep-alive feature for remote connections

### DIFF
--- a/src/redir.c
+++ b/src/redir.c
@@ -605,6 +605,16 @@ static void accept_cb(EV_P_ ev_io *w, int revents)
     setsockopt(remotefd, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof(opt));
 #endif
 
+    //Enable TCP keepalive feature
+    int keepAlive = 1;
+    int keepIdle = 40;
+    int keepInterval = 20;
+    int keepCount = 5;
+    setsockopt(remotefd, SOL_SOCKET, SO_KEEPALIVE, (void*)&keepAlive, sizeof(keepAlive));
+    setsockopt(remotefd, SOL_TCP, TCP_KEEPIDLE, (void*)&keepIdle, sizeof(keepIdle));
+    setsockopt(remotefd, SOL_TCP, TCP_KEEPINTVL, (void*)&keepInterval, sizeof(keepInterval));
+    setsockopt(remotefd, SOL_TCP, TCP_KEEPCNT, (void*)&keepCount, sizeof(keepCount));
+    
     // Setup
     setnonblocking(remotefd);
 


### PR DESCRIPTION
When an OpenWRT router is connected to the Internet via multiple NAT, it's likely that the TCP connections to the remote Shadowsocks server will fail after a few minutes of inactivation without the clients being noticed.  A typical case is that when a LAN user browses google.com for the first time and then browse it again a few minutes later, the browser will reuse the previously established connection which is no longer available and not closed by the router(not even a broken pipe signal is triggered), resulting in connection timeout and the browser reconnecting. To make the remote connections live longer and automatically close broken connections, enabling TCP keep-alive does the trick. I have tested this fix and it works pretty well.