### PR TITLE
update MAX_CONNECT_TIMEOUT from 10 to 120, in order to prevent error …

### DIFF
--- a/src/jconf.h
+++ b/src/jconf.h
@@ -23,10 +23,10 @@
 #define _JCONF_H
 
 #define MAX_PORT_NUM 1024
-#define MAX_REMOTE_NUM 10
+#define MAX_REMOTE_NUM 100
 #define MAX_CONF_SIZE 128 * 1024
 #define MAX_DNS_NUM 4
-#define MAX_CONNECT_TIMEOUT 10
+#define MAX_CONNECT_TIMEOUT 120
 #define MIN_UDP_TIMEOUT 10
 
 typedef struct {


### PR DESCRIPTION
update MAX_CONNECT_TIMEOUT from 10 to 120, in order to prevent error message as 'TCP connection timeout' while connect to slow remote host

the code use min(MAX_CONNECT_TIMEOUT, timeout) , which means timemout will not exceed 10s because MAX_CONNECT_TIMEOUT was defined as 10s