### PR TITLE
add check to avoid Segmentation fault

### DIFF
--- a/src/manager.c
+++ b/src/manager.c
@@ -362,6 +362,9 @@ static void manager_recv_cb(EV_P_ ev_io *w, int revents)
     }
 
     char *action = get_action(buf, r);
+    if (action == NULL) {
+        return;
+    }
 
     if (strcmp(action, "add") == 0) {
         struct server *server = get_server(buf, r);


### PR DESCRIPTION
without checking, segmentation fault will happen when received data only contains **white-space characters**.