### PR TITLE
Fix the crash issue in free_connections

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -198,10 +198,8 @@ int create_and_bind(const char *addr, const char *port)
 
 static void free_connections(struct ev_loop *loop)
 {
-    struct cork_dllist_item *curr;
-    for (curr = cork_dllist_start(&connections);
-         !cork_dllist_is_end(&connections, curr);
-         curr = curr->next) {
+    struct cork_dllist_item *curr, *next;
+    cork_dllist_foreach_void (&connections, curr, next) {
         server_t *server = cork_container_of(curr, server_t, entries);
         remote_t *remote = server->remote;
         close_and_free_server(loop, server);

--- a/src/server.c
+++ b/src/server.c
@@ -205,10 +205,8 @@ static void stat_update_cb(EV_P_ ev_timer *watcher, int revents)
 
 static void free_connections(struct ev_loop *loop)
 {
-    struct cork_dllist_item *curr;
-    for (curr = cork_dllist_start(&connections);
-         !cork_dllist_is_end(&connections, curr);
-         curr = curr->next) {
+    struct cork_dllist_item *curr, *next;
+    cork_dllist_foreach_void (&connections, curr, next) {
         server_t *server = cork_container_of(curr, server_t, entries);
         remote_t *remote = server->remote;
         close_and_free_server(loop, server);


### PR DESCRIPTION
Sometime, ss-local.exe will crash while exiting. Root cause is that close_and_free_server will free the memory of server_t which contains cork_dllist_item (referenced by pointer curr). After that, the next iteration will use the curr->next to get the next item, but at this point the memory pointed by curr has been freed.