### PR TITLE
Polish code

### DIFF
--- a/libipset/bdd/write.c
+++ b/libipset/bdd/write.c
@@ -541,7 +541,8 @@ ipset_node_cache_save_dot(struct cork_stream_consumer *stream,
                           struct ipset_node_cache *cache, ipset_node_id node)
 {
     struct dot_data  dot_data = {
-        0                       /* default value */
+        0,                       /* default value */
+        {NULL, 0, 0}
     };
 
     struct save_data  save_data;

--- a/src/encrypt.c
+++ b/src/encrypt.c
@@ -203,7 +203,8 @@ static int safe_memcmp(const void *s1, const void *s2, size_t n)
 {
     const unsigned char *_s1 = (const unsigned char *)s1;
     const unsigned char *_s2 = (const unsigned char *)s2;
-    int ret                  = 0, i;
+    int ret                  = 0;
+    size_t i;
     for (i = 0; i < n; i++)
         ret |= _s1[i] ^ _s2[i];
     return !!ret;
@@ -219,7 +220,7 @@ int balloc(buffer_t *ptr, size_t capacity)
 
 int brealloc(buffer_t *ptr, size_t len, size_t capacity)
 {
-    int real_capacity = max(len, capacity);
+    size_t real_capacity = max(len, capacity);
     if (ptr->capacity < real_capacity) {
         ptr->array    = realloc(ptr->array, real_capacity);
         ptr->capacity = real_capacity;
@@ -1119,7 +1120,7 @@ int ss_encrypt_all(buffer_t *plain, int method, int auth, size_t capacity)
         size_t iv_len = enc_iv_len;
         int err       = 1;
 
-        static buffer_t tmp = { 0 };
+        static buffer_t tmp = { 0, 0, 0, NULL };
         brealloc(&tmp, iv_len + plain->len, capacity);
         buffer_t *cipher = &tmp;
         cipher->len = plain->len;
@@ -1178,7 +1179,7 @@ int ss_encrypt_all(buffer_t *plain, int method, int auth, size_t capacity)
 int ss_encrypt(buffer_t *plain, enc_ctx_t *ctx, size_t capacity)
 {
     if (ctx != NULL) {
-        static buffer_t tmp = { 0 };
+        static buffer_t tmp = { 0, 0, 0, NULL };
 
         int err       = 1;
         size_t iv_len = 0;
@@ -1261,7 +1262,7 @@ int ss_decrypt_all(buffer_t *cipher, int method, int auth, size_t capacity)
         cipher_ctx_t evp;
         cipher_context_init(&evp, method, 0);
 
-        static buffer_t tmp = { 0 };
+        static buffer_t tmp = { 0, 0, 0, NULL };
         brealloc(&tmp, cipher->len, capacity);
         buffer_t *plain = &tmp;
         plain->len = cipher->len - iv_len;
@@ -1324,7 +1325,7 @@ int ss_decrypt_all(buffer_t *cipher, int method, int auth, size_t capacity)
 int ss_decrypt(buffer_t *cipher, enc_ctx_t *ctx, size_t capacity)
 {
     if (ctx != NULL) {
-        static buffer_t tmp = { 0 };
+        static buffer_t tmp = { 0, 0, 0, NULL };
 
         size_t iv_len = 0;
         int err       = 1;

--- a/src/jconf.c
+++ b/src/jconf.c
@@ -130,7 +130,7 @@ jconf_t *read_jconf(const char *file)
 
     buf[pos] = '\0'; // end of string
 
-    json_settings settings = { 0 };
+    json_settings settings = { 0UL, 0, NULL, NULL, NULL };
     char error_buf[512];
     obj = json_parse_ex(&settings, buf, pos, error_buf);
 
@@ -139,7 +139,7 @@ jconf_t *read_jconf(const char *file)
     }
 
     if (obj->type == json_object) {
-        int i, j;
+        unsigned int i, j;
         for (i = 0; i < obj->u.object.length; i++) {
             char *name        = obj->u.object.values[i].name;
             json_value *value = obj->u.object.values[i].value;

--- a/src/json.c
+++ b/src/json.c
@@ -38,7 +38,7 @@
 #ifdef __cplusplus
 const struct _json_value json_value_none; /* zero-d by ctor */
 #else
-const struct _json_value json_value_none = { 0 };
+const struct _json_value json_value_none = { NULL, 0, {0}, {NULL} };
 #endif
 
 #include <stdio.h>
@@ -239,7 +239,7 @@ json_value *json_parse_ex(json_settings *settings,
     unsigned int cur_line;
     const json_char *cur_line_begin, *i, *end;
     json_value *top, *root, *alloc = 0;
-    json_state state = { 0 };
+    json_state state = { 0UL, 0U, 0UL, {0UL, 0, NULL, NULL, NULL}, 0 };
     long flags;
     long num_digits         = 0, num_e = 0;
     json_int_t num_fraction = 0;
@@ -933,7 +933,7 @@ e_failed:
 
 json_value *json_parse(const json_char *json, size_t length)
 {
-    json_settings settings = { 0 };
+    json_settings settings = { 0UL, 0, NULL, NULL, NULL };
     return json_parse_ex(&settings, json, length, 0);
 }
 
@@ -986,7 +986,7 @@ void json_value_free_ex(json_settings *settings, json_value *value)
 
 void json_value_free(json_value *value)
 {
-    json_settings settings = { 0 };
+    json_settings settings = { 0UL, 0, NULL, NULL, NULL };
     settings.mem_free = default_free;
     json_value_free_ex(&settings, value);
 }

--- a/src/local.c
+++ b/src/local.c
@@ -333,7 +333,7 @@ static void server_recv_cb(EV_P_ ev_io *w, int revents)
                             close_and_free_server(EV_A_ server);
                             return;
                         }
-                    } else if (s <= remote->buf->len) {
+                    } else if (s <= (int)(remote->buf->len)) {
                         remote->buf->len -= s;
                         remote->buf->idx  = s;
                     }
@@ -363,7 +363,7 @@ static void server_recv_cb(EV_P_ ev_io *w, int revents)
                         close_and_free_server(EV_A_ server);
                         return;
                     }
-                } else if (s < remote->buf->len) {
+                } else if (s < (int)(remote->buf->len)) {
                     remote->buf->len -= s;
                     remote->buf->idx  = s;
                     ev_io_stop(EV_A_ & server_recv_ctx->io);
@@ -383,7 +383,7 @@ static void server_recv_cb(EV_P_ ev_io *w, int revents)
             server->stage = 1;
 
             int off = (buf->array[1] & 0xff) + 2;
-            if (buf->array[0] == 0x05 && off < buf->len) {
+            if (buf->array[0] == 0x05 && off < (int)(buf->len)) {
                 memmove(buf->array, buf->array + off, buf->len - off);
                 buf->len -= off;
                 continue;
@@ -590,7 +590,7 @@ static void server_send_cb(EV_P_ ev_io *w, int revents)
                 close_and_free_server(EV_A_ server);
             }
             return;
-        } else if (s < server->buf->len) {
+        } else if (s < (ssize_t)(server->buf->len)) {
             // partly sent, move memory, wait for the next time to send
             server->buf->len -= s;
             server->buf->idx += s;
@@ -695,7 +695,7 @@ static void remote_recv_cb(EV_P_ ev_io *w, int revents)
             close_and_free_server(EV_A_ server);
             return;
         }
-    } else if (s < server->buf->len) {
+    } else if (s < (int)(server->buf->len)) {
         server->buf->len -= s;
         server->buf->idx  = s;
         ev_io_stop(EV_A_ & remote_recv_ctx->io);
@@ -752,7 +752,7 @@ static void remote_send_cb(EV_P_ ev_io *w, int revents)
                 close_and_free_server(EV_A_ server);
             }
             return;
-        } else if (s < remote->buf->len) {
+        } else if (s < (ssize_t)(remote->buf->len)) {
             // partly sent, move memory, wait for the next time to send
             remote->buf->len -= s;
             remote->buf->idx += s;

--- a/src/netutils.c
+++ b/src/netutils.c
@@ -62,7 +62,7 @@ size_t get_sockaddr_len(struct sockaddr *addr)
     return 0;
 }
 
-size_t get_sockaddr(char *host, char *port, struct sockaddr_storage *storage, int block)
+ssize_t get_sockaddr(char *host, char *port, struct sockaddr_storage *storage, int block)
 {
     struct cork_ip ip;
     if (cork_ip_init(&ip, host) != -1) {

--- a/src/netutils.h
+++ b/src/netutils.h
@@ -24,7 +24,7 @@
 #define _NETUTILS_H
 
 size_t get_sockaddr_len(struct sockaddr *addr);
-size_t get_sockaddr(char *host, char *port, struct sockaddr_storage *storage, int block);
+ssize_t get_sockaddr(char *host, char *port, struct sockaddr_storage *storage, int block);
 int set_reuseport(int socket);
 
 #endif


### PR DESCRIPTION
code issues found by Clang with
CFLAGS="-Os -Wall -Wextra -Werror=unused-const-variable -Wno-error=unused-parameter"
enabled

The details as follows:
- variable initialization issue, modified them as Clang suggested
- data type mismatch when comparing, fix them either by casting or changing
  the data type of index of iterator
- get_sockaddr() in netutils may return -1 thus changed returning type from
  size_t to ssize_t, which makes Clang happier
- recvfrom() in udprelay is identical, fix this by creating local variable
  for comparison  and assign back to buf->len when returning value is acceptable

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>