### PR TITLE
Refine memory management

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include "cache.h"
+#include "mm-wrapper.h"
 
 #ifdef __MINGW32__
 #include "win32.h"
@@ -91,13 +92,12 @@ int cache_delete(struct cache *cache, int keep_data)
                     cache->free_cb(entry->data);
                 }
             }
-            free(entry->key);
-            free(entry);
+            SS_SAFEFREE(entry->key);
+            SS_SAFEFREE(entry);
         }
     }
 
-    free(cache);
-    cache = NULL;
+    SS_SAFEFREE(cache);
     return 0;
 }
 
@@ -130,11 +130,11 @@ int cache_remove(struct cache *cache, char *key, size_t key_len)
             if (cache->free_cb) {
                 cache->free_cb(tmp->data);
             } else {
-                free(tmp->data);
+                SS_SAFEFREE(tmp->data);
             }
         }
-        free(tmp->key);
-        free(tmp);
+        SS_SAFEFREE(tmp->key);
+        SS_SAFEFREE(tmp);
     }
 
     return 0;
@@ -230,7 +230,7 @@ int cache_insert(struct cache *cache, char *key, size_t key_len, void *data)
         return ENOMEM;
     }
 
-    entry->key = malloc(key_len);
+    entry->key = SS_SAFEMALLOC(key_len);
     memcpy(entry->key, key, key_len);
     entry->data = data;
     HASH_ADD_KEYPTR(hh, cache->entries, entry->key, key_len, entry);
@@ -242,11 +242,11 @@ int cache_insert(struct cache *cache, char *key, size_t key_len, void *data)
                 if (cache->free_cb) {
                     cache->free_cb(entry->data);
                 } else {
-                    free(entry->data);
+                    SS_SAFEFREE(entry->data);
                 }
             }
-            free(entry->key);
-            free(entry);
+            SS_SAFEFREE(entry->key);
+            SS_SAFEFREE(entry);
             break;
         }
     }

--- a/src/jconf.c
+++ b/src/jconf.c
@@ -29,6 +29,7 @@
 #include "jconf.h"
 #include "json.h"
 #include "string.h"
+#include "mm-wrapper.h"
 
 #include <libcork/core.h>
 
@@ -49,10 +50,8 @@ static char *to_string(const json_value *value)
 
 void free_addr(ss_addr_t *addr)
 {
-    free(addr->host);
-    free(addr->port);
-    addr->host = NULL;
-    addr->port = NULL;
+    SS_SAFEFREE(addr->host);
+    SS_SAFEFREE(addr->port);
 }
 
 void parse_addr(const char *str, ss_addr_t *addr)
@@ -117,7 +116,7 @@ jconf_t *read_jconf(const char *file)
         FATAL("Too large config file.");
     }
 
-    buf = malloc(pos + 1);
+    buf = SS_SAFEMALLOC(pos + 1);
     if (buf == NULL) {
         FATAL("No enough memory.");
     }
@@ -199,7 +198,7 @@ jconf_t *read_jconf(const char *file)
         FATAL("Invalid config file");
     }
 
-    free(buf);
+    SS_SAFEFREE(buf);
     json_value_free(obj);
     return &conf;
 }

--- a/src/json.c
+++ b/src/json.c
@@ -28,6 +28,7 @@
  */
 
 #include "json.h"
+#include "mm-wrapper.h"
 
 #ifdef _MSC_VER
 #ifndef _CRT_SECURE_NO_WARNINGS
@@ -90,12 +91,12 @@ typedef struct {
 
 static void *default_alloc(size_t size, int zero, void *user_data)
 {
-    return zero ? calloc(1, size) : malloc(size);
+    return zero ? calloc(1, size) : SS_SAFEMALLOC(size);
 }
 
 static void default_free(void *ptr, void *user_data)
 {
-    free(ptr);
+    SS_SAFEFREE(ptr);
 }
 
 static void *json_alloc(json_state *state, unsigned long size, int zero)

--- a/src/local.c
+++ b/src/local.c
@@ -66,6 +66,7 @@
 #include "socks5.h"
 #include "acl.h"
 #include "local.h"
+#include "mm-wrapper.h"
 
 #ifndef EAGAIN
 #define EAGAIN EWOULDBLOCK
@@ -770,13 +771,13 @@ static void remote_send_cb(EV_P_ ev_io *w, int revents)
 static remote_t *new_remote(int fd, int timeout)
 {
     remote_t *remote;
-    remote = malloc(sizeof(remote_t));
+    remote = SS_SAFEMALLOC(sizeof(remote_t));
 
     memset(remote, 0, sizeof(remote_t));
 
-    remote->buf                 = malloc(sizeof(buffer_t));
-    remote->recv_ctx            = malloc(sizeof(remote_ctx_t));
-    remote->send_ctx            = malloc(sizeof(remote_ctx_t));
+    remote->buf                 = SS_SAFEMALLOC(sizeof(buffer_t));
+    remote->recv_ctx            = SS_SAFEMALLOC(sizeof(remote_ctx_t));
+    remote->send_ctx            = SS_SAFEMALLOC(sizeof(remote_ctx_t));
     remote->recv_ctx->connected = 0;
     remote->send_ctx->connected = 0;
     remote->fd                  = fd;
@@ -802,11 +803,11 @@ static void free_remote(remote_t *remote)
     }
     if (remote->buf != NULL) {
         bfree(remote->buf);
-        free(remote->buf);
+        SS_SAFEFREE(remote->buf);
     }
-    free(remote->recv_ctx);
-    free(remote->send_ctx);
-    free(remote);
+    SS_SAFEFREE(remote->recv_ctx);
+    SS_SAFEFREE(remote->send_ctx);
+    SS_SAFEFREE(remote);
 }
 
 static void close_and_free_remote(EV_P_ remote_t *remote)
@@ -824,13 +825,13 @@ static void close_and_free_remote(EV_P_ remote_t *remote)
 static server_t *new_server(int fd, int method)
 {
     server_t *server;
-    server = malloc(sizeof(server_t));
+    server = SS_SAFEMALLOC(sizeof(server_t));
 
     memset(server, 0, sizeof(server_t));
 
-    server->recv_ctx            = malloc(sizeof(server_ctx_t));
-    server->send_ctx            = malloc(sizeof(server_ctx_t));
-    server->buf                 = malloc(sizeof(buffer_t));
+    server->recv_ctx            = SS_SAFEMALLOC(sizeof(server_ctx_t));
+    server->send_ctx            = SS_SAFEMALLOC(sizeof(server_ctx_t));
+    server->buf                 = SS_SAFEMALLOC(sizeof(buffer_t));
     server->recv_ctx->connected = 0;
     server->send_ctx->connected = 0;
     server->fd                  = fd;
@@ -838,8 +839,8 @@ static server_t *new_server(int fd, int method)
     server->send_ctx->server    = server;
 
     if (method) {
-        server->e_ctx = malloc(sizeof(struct enc_ctx));
-        server->d_ctx = malloc(sizeof(struct enc_ctx));
+        server->e_ctx = SS_SAFEMALLOC(sizeof(struct enc_ctx));
+        server->d_ctx = SS_SAFEMALLOC(sizeof(struct enc_ctx));
         enc_ctx_init(method, server->e_ctx, 1);
         enc_ctx_init(method, server->d_ctx, 0);
     } else {
@@ -866,19 +867,19 @@ static void free_server(server_t *server)
     }
     if (server->e_ctx != NULL) {
         cipher_context_release(&server->e_ctx->evp);
-        free(server->e_ctx);
+        SS_SAFEFREE(server->e_ctx);
     }
     if (server->d_ctx != NULL) {
         cipher_context_release(&server->d_ctx->evp);
-        free(server->d_ctx);
+        SS_SAFEFREE(server->d_ctx);
     }
     if (server->buf != NULL) {
         bfree(server->buf);
-        free(server->buf);
+        SS_SAFEFREE(server->buf);
     }
-    free(server->recv_ctx);
-    free(server->send_ctx);
-    free(server);
+    SS_SAFEFREE(server->recv_ctx);
+    SS_SAFEFREE(server->send_ctx);
+    SS_SAFEFREE(server);
 }
 
 static void close_and_free_server(EV_P_ server_t *server)
@@ -1184,12 +1185,12 @@ int main(int argc, char **argv)
     // Setup proxy context
     listen_ctx_t listen_ctx;
     listen_ctx.remote_num  = remote_num;
-    listen_ctx.remote_addr = malloc(sizeof(struct sockaddr *) * remote_num);
+    listen_ctx.remote_addr = SS_SAFEMALLOC(sizeof(struct sockaddr *) * remote_num);
     for (i = 0; i < remote_num; i++) {
         char *host = remote_addr[i].host;
         char *port = remote_addr[i].port == NULL ? remote_port :
                      remote_addr[i].port;
-        struct sockaddr_storage *storage = malloc(sizeof(struct sockaddr_storage));
+        struct sockaddr_storage *storage = SS_SAFEMALLOC(sizeof(struct sockaddr_storage));
         memset(storage, 0, sizeof(struct sockaddr_storage));
         if (get_sockaddr(host, port, storage, 1) == -1) {
             FATAL("failed to resolve the provided hostname");
@@ -1252,8 +1253,8 @@ int main(int argc, char **argv)
     }
 
     for (i = 0; i < remote_num; i++)
-        free(listen_ctx.remote_addr[i]);
-    free(listen_ctx.remote_addr);
+        SS_SAFEFREE(listen_ctx.remote_addr[i]);
+    SS_SAFEFREE(listen_ctx.remote_addr);
 
 #ifdef __MINGW32__
     winsock_cleanup();
@@ -1319,7 +1320,7 @@ int start_ss_local_server(profile_t profile)
     LOGI("initialize ciphers... %s", method);
     int m = enc_init(password, method);
 
-    struct sockaddr_storage *storage = malloc(sizeof(struct sockaddr_storage));
+    struct sockaddr_storage *storage = SS_SAFEMALLOC(sizeof(struct sockaddr_storage));
     memset(storage, 0, sizeof(struct sockaddr_storage));
     if (get_sockaddr(remote_host, remote_port_str, storage, 1) == -1) {
         return -1;
@@ -1330,7 +1331,7 @@ int start_ss_local_server(profile_t profile)
     listen_ctx_t listen_ctx;
 
     listen_ctx.remote_num     = 1;
-    listen_ctx.remote_addr    = malloc(sizeof(struct sockaddr *));
+    listen_ctx.remote_addr    = SS_SAFEMALLOC(sizeof(struct sockaddr *));
     listen_ctx.remote_addr[0] = (struct sockaddr *)storage;
     listen_ctx.timeout        = timeout;
     listen_ctx.method         = m;
@@ -1383,7 +1384,7 @@ int start_ss_local_server(profile_t profile)
     free_connections(loop);
     close(listen_ctx.fd);
 
-    free(listen_ctx.remote_addr);
+    SS_SAFEFREE(listen_ctx.remote_addr);
 
 #ifdef __MINGW32__
     winsock_cleanup();

--- a/src/mm-wrapper.h
+++ b/src/mm-wrapper.h
@@ -1,0 +1,52 @@
+/*
+ * mm-wrapper.h - Define safe memory management wrapper
+ *
+ * Copyright (C) 2013 - 2016, Max Lv <max.c.lv@gmail.com>
+ *
+ * This file is part of the shadowsocks-libev.
+ * shadowsocks-libev is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * shadowsocks-libev is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with shadowsocks-libev; see the file COPYING. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _MM_WRAPPER_H
+#define _MM_WRAPPER_H
+
+#include <stdlib.h>
+
+#define SS_SAFEFREE(ptr) \
+    do {                 \
+        free(ptr);       \
+        ptr = NULL;      \
+    } while(0)
+
+static inline void *SS_SAFEMALLOC(size_t size);
+static inline void *SS_SAFEREALLOC(void *ptr, size_t new_size);
+
+static inline void *SS_SAFEMALLOC(size_t size) {
+    void *tmp = malloc(size);
+    if (tmp == NULL)
+        exit(EXIT_FAILURE);
+    return tmp;
+}
+
+static inline void *SS_SAFEREALLOC(void *ptr, size_t new_size) {
+    void *new = realloc(ptr, new_size);
+    if (new == NULL) {
+        free(ptr); ptr = NULL;
+        exit(EXIT_FAILURE);
+    }
+    return new;
+}
+
+#endif // _MM_WRAPPER_H

--- a/src/redir.c
+++ b/src/redir.c
@@ -49,6 +49,7 @@
 #include "utils.h"
 #include "common.h"
 #include "redir.h"
+#include "mm-wrapper.h"
 
 #ifndef EAGAIN
 #define EAGAIN EWOULDBLOCK
@@ -452,13 +453,13 @@ static void remote_send_cb(EV_P_ ev_io *w, int revents)
 static remote_t *new_remote(int fd, int timeout)
 {
     remote_t *remote;
-    remote = malloc(sizeof(remote_t));
+    remote = SS_SAFEMALLOC(sizeof(remote_t));
 
     memset(remote, 0, sizeof(remote_t));
 
-    remote->recv_ctx            = malloc(sizeof(remote_ctx_t));
-    remote->send_ctx            = malloc(sizeof(remote_ctx_t));
-    remote->buf                 = malloc(sizeof(buffer_t));
+    remote->recv_ctx            = SS_SAFEMALLOC(sizeof(remote_ctx_t));
+    remote->send_ctx            = SS_SAFEMALLOC(sizeof(remote_ctx_t));
+    remote->buf                 = SS_SAFEMALLOC(sizeof(buffer_t));
     remote->fd                  = fd;
     remote->recv_ctx->remote    = remote;
     remote->recv_ctx->connected = 0;
@@ -483,11 +484,11 @@ static void free_remote(remote_t *remote)
         }
         if (remote->buf != NULL) {
             bfree(remote->buf);
-            free(remote->buf);
+            SS_SAFEFREE(remote->buf);
         }
-        free(remote->recv_ctx);
-        free(remote->send_ctx);
-        free(remote);
+        SS_SAFEFREE(remote->recv_ctx);
+        SS_SAFEFREE(remote->send_ctx);
+        SS_SAFEFREE(remote);
     }
 }
 
@@ -505,11 +506,11 @@ static void close_and_free_remote(EV_P_ remote_t *remote)
 static server_t *new_server(int fd, int method)
 {
     server_t *server;
-    server = malloc(sizeof(server_t));
+    server = SS_SAFEMALLOC(sizeof(server_t));
 
-    server->recv_ctx            = malloc(sizeof(server_ctx_t));
-    server->send_ctx            = malloc(sizeof(server_ctx_t));
-    server->buf                 = malloc(sizeof(buffer_t));
+    server->recv_ctx            = SS_SAFEMALLOC(sizeof(server_ctx_t));
+    server->send_ctx            = SS_SAFEMALLOC(sizeof(server_ctx_t));
+    server->buf                 = SS_SAFEMALLOC(sizeof(buffer_t));
     server->fd                  = fd;
     server->recv_ctx->server    = server;
     server->recv_ctx->connected = 0;
@@ -517,8 +518,8 @@ static server_t *new_server(int fd, int method)
     server->send_ctx->connected = 0;
 
     if (method) {
-        server->e_ctx = malloc(sizeof(enc_ctx_t));
-        server->d_ctx = malloc(sizeof(enc_ctx_t));
+        server->e_ctx = SS_SAFEMALLOC(sizeof(enc_ctx_t));
+        server->d_ctx = SS_SAFEMALLOC(sizeof(enc_ctx_t));
         enc_ctx_init(method, server->e_ctx, 1);
         enc_ctx_init(method, server->d_ctx, 0);
     } else {
@@ -542,19 +543,19 @@ static void free_server(server_t *server)
         }
         if (server->e_ctx != NULL) {
             cipher_context_release(&server->e_ctx->evp);
-            free(server->e_ctx);
+            SS_SAFEFREE(server->e_ctx);
         }
         if (server->d_ctx != NULL) {
             cipher_context_release(&server->d_ctx->evp);
-            free(server->d_ctx);
+            SS_SAFEFREE(server->d_ctx);
         }
         if (server->buf != NULL) {
             bfree(server->buf);
-            free(server->buf);
+            SS_SAFEFREE(server->buf);
         }
-        free(server->recv_ctx);
-        free(server->send_ctx);
-        free(server);
+        SS_SAFEFREE(server->recv_ctx);
+        SS_SAFEFREE(server->send_ctx);
+        SS_SAFEFREE(server);
     }
 }
 
@@ -797,12 +798,12 @@ int main(int argc, char **argv)
     // Setup proxy context
     listen_ctx_t listen_ctx;
     listen_ctx.remote_num  = remote_num;
-    listen_ctx.remote_addr = malloc(sizeof(struct sockaddr *) * remote_num);
+    listen_ctx.remote_addr = SS_SAFEMALLOC(sizeof(struct sockaddr *) * remote_num);
     for (int i = 0; i < remote_num; i++) {
         char *host = remote_addr[i].host;
         char *port = remote_addr[i].port == NULL ? remote_port :
                      remote_addr[i].port;
-        struct sockaddr_storage *storage = malloc(sizeof(struct sockaddr_storage));
+        struct sockaddr_storage *storage = SS_SAFEMALLOC(sizeof(struct sockaddr_storage));
         memset(storage, 0, sizeof(struct sockaddr_storage));
         if (get_sockaddr(host, port, storage, 1) == -1) {
             FATAL("failed to resolve the provided hostname");

--- a/src/server.c
+++ b/src/server.c
@@ -64,6 +64,7 @@
 #include "utils.h"
 #include "acl.h"
 #include "server.h"
+#include "mm-wrapper.h"
 
 #ifndef EAGAIN
 #define EAGAIN EWOULDBLOCK
@@ -1099,10 +1100,10 @@ static remote_t *new_remote(int fd)
 
     remote_t *remote;
 
-    remote                      = malloc(sizeof(remote_t));
-    remote->recv_ctx            = malloc(sizeof(remote_ctx_t));
-    remote->send_ctx            = malloc(sizeof(remote_ctx_t));
-    remote->buf                 = malloc(sizeof(buffer_t));
+    remote                      = SS_SAFEMALLOC(sizeof(remote_t));
+    remote->recv_ctx            = SS_SAFEMALLOC(sizeof(remote_ctx_t));
+    remote->send_ctx            = SS_SAFEMALLOC(sizeof(remote_ctx_t));
+    remote->buf                 = SS_SAFEMALLOC(sizeof(buffer_t));
     remote->fd                  = fd;
     remote->recv_ctx->remote    = remote;
     remote->recv_ctx->connected = 0;
@@ -1125,11 +1126,11 @@ static void free_remote(remote_t *remote)
     }
     if (remote->buf != NULL) {
         bfree(remote->buf);
-        free(remote->buf);
+        SS_SAFEFREE(remote->buf);
     }
-    free(remote->recv_ctx);
-    free(remote->send_ctx);
-    free(remote);
+    SS_SAFEFREE(remote->recv_ctx);
+    SS_SAFEFREE(remote->send_ctx);
+    SS_SAFEFREE(remote);
 }
 
 static void close_and_free_remote(EV_P_ remote_t *remote)
@@ -1153,13 +1154,13 @@ static server_t *new_server(int fd, listen_ctx_t *listener)
     }
 
     server_t *server;
-    server = malloc(sizeof(server_t));
+    server = SS_SAFEMALLOC(sizeof(server_t));
 
     memset(server, 0, sizeof(server_t));
 
-    server->recv_ctx            = malloc(sizeof(server_ctx_t));
-    server->send_ctx            = malloc(sizeof(server_ctx_t));
-    server->buf                 = malloc(sizeof(buffer_t));
+    server->recv_ctx            = SS_SAFEMALLOC(sizeof(server_ctx_t));
+    server->send_ctx            = SS_SAFEMALLOC(sizeof(server_ctx_t));
+    server->buf                 = SS_SAFEMALLOC(sizeof(buffer_t));
     server->fd                  = fd;
     server->recv_ctx->server    = server;
     server->recv_ctx->connected = 0;
@@ -1171,8 +1172,8 @@ static server_t *new_server(int fd, listen_ctx_t *listener)
     server->remote              = NULL;
 
     if (listener->method) {
-        server->e_ctx = malloc(sizeof(enc_ctx_t));
-        server->d_ctx = malloc(sizeof(enc_ctx_t));
+        server->e_ctx = SS_SAFEMALLOC(sizeof(enc_ctx_t));
+        server->d_ctx = SS_SAFEMALLOC(sizeof(enc_ctx_t));
         enc_ctx_init(listener->method, server->e_ctx, 1);
         enc_ctx_init(listener->method, server->d_ctx, 0);
     } else {
@@ -1189,7 +1190,7 @@ static server_t *new_server(int fd, listen_ctx_t *listener)
 
     server->chunk = (chunk_t *)malloc(sizeof(chunk_t));
     memset(server->chunk, 0, sizeof(chunk_t));
-    server->chunk->buf = malloc(sizeof(buffer_t));
+    server->chunk->buf = SS_SAFEMALLOC(sizeof(buffer_t));
     memset(server->chunk->buf, 0, sizeof(buffer_t));
 
     cork_dllist_add(&connections, &server->entries);
@@ -1204,31 +1205,29 @@ static void free_server(server_t *server)
     if (server->chunk != NULL) {
         if (server->chunk->buf != NULL) {
             bfree(server->chunk->buf);
-            free(server->chunk->buf);
-            server->chunk->buf = NULL;
+            SS_SAFEFREE(server->chunk->buf);
         }
-        free(server->chunk);
-        server->chunk = NULL;
+        SS_SAFEFREE(server->chunk);
     }
     if (server->remote != NULL) {
         server->remote->server = NULL;
     }
     if (server->e_ctx != NULL) {
         cipher_context_release(&server->e_ctx->evp);
-        free(server->e_ctx);
+        SS_SAFEFREE(server->e_ctx);
     }
     if (server->d_ctx != NULL) {
         cipher_context_release(&server->d_ctx->evp);
-        free(server->d_ctx);
+        SS_SAFEFREE(server->d_ctx);
     }
     if (server->buf != NULL) {
         bfree(server->buf);
-        free(server->buf);
+        SS_SAFEFREE(server->buf);
     }
 
-    free(server->recv_ctx);
-    free(server->send_ctx);
-    free(server);
+    SS_SAFEFREE(server->recv_ctx);
+    SS_SAFEFREE(server->send_ctx);
+    SS_SAFEFREE(server);
 }
 
 static void close_and_free_server(EV_P_ server_t *server)

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -58,6 +58,7 @@
 #include "netutils.h"
 #include "utils.h"
 #include "tunnel.h"
+#include "mm-wrapper.h"
 
 #ifndef EAGAIN
 #define EAGAIN EWOULDBLOCK
@@ -500,13 +501,13 @@ static void remote_send_cb(EV_P_ ev_io *w, int revents)
 static remote_t *new_remote(int fd, int timeout)
 {
     remote_t *remote;
-    remote = malloc(sizeof(remote_t));
+    remote = SS_SAFEMALLOC(sizeof(remote_t));
 
     memset(remote, 0, sizeof(remote_t));
 
-    remote->buf                 = malloc(sizeof(buffer_t));
-    remote->recv_ctx            = malloc(sizeof(remote_ctx_t));
-    remote->send_ctx            = malloc(sizeof(remote_ctx_t));
+    remote->buf                 = SS_SAFEMALLOC(sizeof(buffer_t));
+    remote->recv_ctx            = SS_SAFEMALLOC(sizeof(remote_ctx_t));
+    remote->send_ctx            = SS_SAFEMALLOC(sizeof(remote_ctx_t));
     remote->fd                  = fd;
     remote->recv_ctx->remote    = remote;
     remote->recv_ctx->connected = 0;
@@ -531,11 +532,11 @@ static void free_remote(remote_t *remote)
         }
         if (remote->buf) {
             bfree(remote->buf);
-            free(remote->buf);
+            SS_SAFEFREE(remote->buf);
         }
-        free(remote->recv_ctx);
-        free(remote->send_ctx);
-        free(remote);
+        SS_SAFEFREE(remote->recv_ctx);
+        SS_SAFEFREE(remote->send_ctx);
+        SS_SAFEFREE(remote);
     }
 }
 
@@ -554,10 +555,10 @@ static server_t *new_server(int fd, int method)
 {
     server_t *server;
 
-    server                      = malloc(sizeof(server_t));
-    server->buf                 = malloc(sizeof(buffer_t));
-    server->recv_ctx            = malloc(sizeof(server_ctx_t));
-    server->send_ctx            = malloc(sizeof(server_ctx_t));
+    server                      = SS_SAFEMALLOC(sizeof(server_t));
+    server->buf                 = SS_SAFEMALLOC(sizeof(buffer_t));
+    server->recv_ctx            = SS_SAFEMALLOC(sizeof(server_ctx_t));
+    server->send_ctx            = SS_SAFEMALLOC(sizeof(server_ctx_t));
     server->fd                  = fd;
     server->recv_ctx->server    = server;
     server->recv_ctx->connected = 0;
@@ -565,8 +566,8 @@ static server_t *new_server(int fd, int method)
     server->send_ctx->connected = 0;
 
     if (method) {
-        server->e_ctx = malloc(sizeof(struct enc_ctx));
-        server->d_ctx = malloc(sizeof(struct enc_ctx));
+        server->e_ctx = SS_SAFEMALLOC(sizeof(struct enc_ctx));
+        server->d_ctx = SS_SAFEMALLOC(sizeof(struct enc_ctx));
         enc_ctx_init(method, server->e_ctx, 1);
         enc_ctx_init(method, server->d_ctx, 0);
     } else {
@@ -590,19 +591,19 @@ static void free_server(server_t *server)
         }
         if (server->e_ctx != NULL) {
             cipher_context_release(&server->e_ctx->evp);
-            free(server->e_ctx);
+            SS_SAFEFREE(server->e_ctx);
         }
         if (server->d_ctx != NULL) {
             cipher_context_release(&server->d_ctx->evp);
-            free(server->d_ctx);
+            SS_SAFEFREE(server->d_ctx);
         }
         if (server->buf) {
             bfree(server->buf);
-            free(server->buf);
+            SS_SAFEFREE(server->buf);
         }
-        free(server->recv_ctx);
-        free(server->send_ctx);
-        free(server);
+        SS_SAFEFREE(server->recv_ctx);
+        SS_SAFEFREE(server->send_ctx);
+        SS_SAFEFREE(server);
     }
 }
 
@@ -876,12 +877,12 @@ int main(int argc, char **argv)
     struct listen_ctx listen_ctx;
     listen_ctx.tunnel_addr = tunnel_addr;
     listen_ctx.remote_num  = remote_num;
-    listen_ctx.remote_addr = malloc(sizeof(struct sockaddr *) * remote_num);
+    listen_ctx.remote_addr = SS_SAFEMALLOC(sizeof(struct sockaddr *) * remote_num);
     for (i = 0; i < remote_num; i++) {
         char *host = remote_addr[i].host;
         char *port = remote_addr[i].port == NULL ? remote_port :
                      remote_addr[i].port;
-        struct sockaddr_storage *storage = malloc(sizeof(struct sockaddr_storage));
+        struct sockaddr_storage *storage = SS_SAFEMALLOC(sizeof(struct sockaddr_storage));
         memset(storage, 0, sizeof(struct sockaddr_storage));
         if (get_sockaddr(host, port, storage, 1) == -1) {
             FATAL("failed to resolve the provided hostname");


### PR DESCRIPTION
- Added one macro to avoid dangling pointers
- Added two functions to perform NULL pointer check
  since the allocation is not guaranteed by C library, although it
  is a rare case, just for sanity
- Add NULL pointer check to brealloc() and bfree() and for sanity as well

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>