### PR TITLE
compare port as well

### DIFF
--- a/src/udprelay.c
+++ b/src/udprelay.c
@@ -1024,7 +1024,7 @@ static void server_recv_cb(EV_P_ ev_io *w, int revents)
     cache_lookup(conn_cache, key, HASH_KEY_LEN, (void *)&remote_ctx);
 
     if (remote_ctx != NULL) {
-        if (sockaddr_cmp_addr(&src_addr, &remote_ctx->src_addr, sizeof(src_addr))) {
+        if (sockaddr_cmp(&src_addr, &remote_ctx->src_addr, sizeof(src_addr))) {
             remote_ctx = NULL;
         }
     }


### PR DESCRIPTION
The whole remote_ctx is inserted into the cache and sockaddr_storage contains
both address and port.

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>