### PR TITLE
Fix compile on 32-bit machine

### DIFF
--- a/src/redir.c
+++ b/src/redir.c
@@ -209,7 +209,7 @@ static void server_recv_cb(EV_P_ ev_io *w, int revents)
             port = ntohs(sa->sin6_port);
         }
 
-        LOGI("redir to %s:%d, len=%ld", ipstr, port, r);
+        LOGI("redir to %s:%d, len=%zd", ipstr, port, r);
     }
 
     remote->buf->len = r;


### PR DESCRIPTION
redir.c:212:9: error: format ‘%ld’ expects argument of type ‘long int’, but argument 5 has type ‘ssize_t’ [-Werror=format=]
         LOGI("redir to %s:%d, len=%ld", ipstr, port, r);
         ^