### PR TITLE
manpage updates

### DIFF
--- a/man/shadowsocks-libev.8
+++ b/man/shadowsocks-libev.8
@@ -95,6 +95,8 @@ Use a configuration file.
 .B \-n \fInumber\fP
 Specify max number of open files.
 
+Not available in manager mode.
+
 Only available on Linux.
 .TP
 .B \-i \fIinterface\fP

--- a/man/shadowsocks-libev.8
+++ b/man/shadowsocks-libev.8
@@ -80,6 +80,9 @@ chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
 If built with PolarSSL or custom OpenSSL libraries, some of these ciphers may
 not work.
 .TP
+.B \-a \fIuser_name\fP
+Run as a specific user.
+.TP
 .B \-f \fIpid_file\fP
 Start shadowsocks as a daemon with specific pid file.
 .TP
@@ -103,9 +106,6 @@ Not available in redir mode.
 Specify local address to bind.
 
 Not available in server mode.
-.TP
-.B \-a \fIuser_name\fP
-Run as a specific user.
 .TP
 .B \-u
 Enable UDP relay.

--- a/man/shadowsocks-libev.8
+++ b/man/shadowsocks-libev.8
@@ -84,7 +84,7 @@ not work.
 Start shadowsocks as a daemon with specific pid file.
 .TP
 .B \-t \fItimeout\fP
-Set the socket timeout in seconds. The default value is 10.
+Set the socket timeout in seconds. The default value is 60.
 .TP
 .B \-c \fIconfig_file\fP
 Use a configuration file.

--- a/man/shadowsocks-libev.8
+++ b/man/shadowsocks-libev.8
@@ -1,7 +1,7 @@
 .ig
 . manual page for shadowsocks-libev
 .
-. Copyright (c) 2012-2015, by: Max Lv
+. Copyright (c) 2012-2016, by: Max Lv
 . All rights reserved.
 .
 . Permission is granted to copy, distribute and/or modify this document
@@ -25,7 +25,7 @@
 .ds Ma  \fBss-manager\fR
 .ds Me  \fBShadowsocks-libev\fR
 .
-.TH "SHADOWSOCKS-LIBEV" "8" "September 10, 2015" "SHADOWSOCKS-LIBEV"
+.TH "SHADOWSOCKS-LIBEV" "8" "April 19, 2016" "SHADOWSOCKS-LIBEV"
 .SH NAME
 shadowsocks-libev \- a lightweight and secure socks5 proxy
 

--- a/man/shadowsocks-libev.8
+++ b/man/shadowsocks-libev.8
@@ -42,17 +42,18 @@ shadowsocks created by clowwindy. \*(Me is written in pure C and takes advantage
 of \fBlibev\fP to achieve both high performance and low resource consumption.
 .PP
 \*(Me consists of five components. One is \*(Se(1) that runs on a remote server
-to provide secured tunnel service. \*(Lo(1) and \*(Re(1) are clients on your local
-machines to proxy TCP traffic. \*(Tu(1) is a tool for local port forwarding.
+to provide secured tunnel service. \*(Lo(1) and \*(Re(1) are clients on your
+local machines to proxy TCP traffic. \*(Tu(1) is a tool for local port
+forwarding.
 .PP
-While \*(Lo(1) works as a standard socks5 proxy, \*(Re(1) works as a transparent proxy
-and requires netfilter's NAT module. For more information, check out the example
-section.
+While \*(Lo(1) works as a standard socks5 proxy, \*(Re(1) works as a transparent
+proxy and requires netfilter's NAT module. For more information, check out the
+example section.
 .PP
-\*(Ma(1) is a controller for multi-user management and traffic statistics, using UNIX
-domain socket to talk with \*(Se(1). Also, it provides a UNIX domain socket or IP based
-API for other software. About the details of this API, please refer to the protocol
-section.
+\*(Ma(1) is a controller for multi-user management and traffic statistics, using
+UNIX domain socket to talk with \*(Se(1). Also, it provides a UNIX domain socket
+or IP based API for other software. About the details of this API, please refer
+to the protocol section.
 
 .SH OPTIONS
 .TP
@@ -71,10 +72,10 @@ Set the password. The server and the client should use the same password.
 .B \-m \fIencrypt_method\fP
 Set the cipher.
 
-\*(Me accepts 18 different ciphers: table, rc4, rc4-md5,
-aes-128-cfb, aes-192-cfb, aes-256-cfb, bf-cfb, camellia-128-cfb,
-camellia-192-cfb, camellia-256-cfb, cast5-cfb, des-cfb, idea-cfb, rc2-cfb,
-seed-cfb, salsa20, chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
+\*(Me accepts 18 different ciphers: table, rc4, rc4-md5, aes-128-cfb,
+aes-192-cfb, aes-256-cfb, bf-cfb, camellia-128-cfb, camellia-192-cfb,
+camellia-256-cfb, cast5-cfb, des-cfb, idea-cfb, rc2-cfb, seed-cfb, salsa20,
+chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
 
 If built with PolarSSL or custom OpenSSL libraries, some of these ciphers may
 not work.
@@ -108,10 +109,12 @@ Run as a specific user.
 .TP
 .B \-u
 Enable UDP relay.
+
 TPROXY is required in redir mode.
 .TP
 .B \-U
 Enable UDP relay and disable TCP relay.
+
 Not available in local mode.
 .TP
 .B \-A
@@ -123,8 +126,8 @@ Specify destination server address and port for local port forwarding.
 Only available in tunnel mode.
 .TP
 .B \-d \fIaddr\fP
-Setup name servers for internal DNS resolver (libudns). The default server
-is fetched from /etc/resolv.conf.
+Setup name servers for internal DNS resolver (libudns). The default server is
+fetched from /etc/resolv.conf.
 
 Only available in server mode.
 .TP
@@ -135,14 +138,17 @@ Only available in local and server mode, with Linux kernel > 3.7.0.
 .TP
 .B \--acl \fIacl_config\fP
 Enable ACL (Access Control List) and specify config file.
+
 Only available in local and server mode.
 .TP
 .B \--manager-address \fIpath_to_unix_domain\fP
 Specify UNIX domain socket address.
+
 Only available in server and manager mode.
 .TP
 .B \--executable \fIpath_to_server_executable\fP
 Specify the executable path of ss-server.
+
 Only available in manager mode.
 .TP
 .B \-v
@@ -151,8 +157,10 @@ Enable verbose mode.
 .SH EXAMPLE
 \*(Re requires netfilter's NAT function. Here is an example:
 
+.nf
     # Create new chain
     root@Wrt:~# iptables -t nat -N SHADOWSOCKS
+    root@Wrt:~# iptables -t mangle -N SHADOWSOCKS
 
     # Ignore your shadowsocks server's addresses
     # It's very IMPORTANT, just be careful.
@@ -184,29 +192,32 @@ Enable verbose mode.
 
     # Start the shadowsocks-redir
     root@Wrt:~# ss-redir -u -c /etc/config/shadowsocks.json -f /var/run/shadowsocks.pid
+.fi
 
 .SH PROTOCOL
 \*(Ma(1) provides several APIs through UDP protocol:
 
-    Send UDP commands in the following format to the manager-address provided to \*(Ma(1).
+.in +4n
+Send UDP commands in the following format to the manager-address provided to
+\*(Ma(1).
 
-        command: [JSON data]
+    command: [JSON data]
 
-    To add a port:
+To add a port:
 
-        add: {"server_port": 8001, "password":"7cd308cc059"}
+    add: {"server_port": 8001, "password":"7cd308cc059"}
 
-    To remove a port:
+To remove a port:
 
-        remove: {"server_port": 8001}
+    remove: {"server_port": 8001}
 
-    To receive a pong:
+To receive a pong:
 
-        ping
+    ping
 
-    Then \*(Ma(1) will send back the traffic statistics:
+Then \*(Ma(1) will send back the traffic statistics:
 
-        stat: {"8001":11370}
+    stat: {"8001":11370}
 
 .SH SEE ALSO
 .BR \*(Lo (1),

--- a/man/shadowsocks-libev.8
+++ b/man/shadowsocks-libev.8
@@ -62,9 +62,13 @@ Set the server's hostname or IP.
 .TP
 .B \-p \fIserver_port\fP
 Set the server's port number.
+
+Not available in manager mode.
 .TP
 .B \-l \fIlocal_port\fP
 Set the local port number.
+
+Not available in server nor manager mode.
 .TP
 .B \-k \fIpassword\fP
 Set the password. The server and the client should use the same password.
@@ -107,7 +111,7 @@ Not available in redir mode.
 .B \-b \fIlocal_address\fP
 Specify local address to bind.
 
-Not available in server mode.
+Not available in server nor manager mode.
 .TP
 .B \-u
 Enable UDP relay.
@@ -134,17 +138,17 @@ Only available in tunnel mode.
 Setup name servers for internal DNS resolver (libudns). The default server is
 fetched from /etc/resolv.conf.
 
-Only available in server mode.
+Only available in server and manager mode.
 .TP
 .B \--fast-open
 Enable TCP fast open.
 
-Only available in local and server mode, with Linux kernel > 3.7.0.
+Not available in redir nor tunnel mode, with Linux kernel > 3.7.0.
 .TP
 .B \--acl \fIacl_config\fP
 Enable ACL (Access Control List) and specify config file.
 
-Only available in local and server mode.
+Not available in redir nor tunnel mode.
 .TP
 .B \--manager-address \fIpath_to_unix_domain\fP
 Specify UNIX domain socket address.

--- a/man/shadowsocks-libev.8
+++ b/man/shadowsocks-libev.8
@@ -128,6 +128,8 @@ Enable onetime authentication.
 .TP
 .B \-w
 Enable white list mode (when ACL enabled).
+
+Only available in server mode.
 .TP
 .B \-L \fIaddr\fR:\fIport\fP
 Specify destination server address and port for local port forwarding.

--- a/man/shadowsocks-libev.8
+++ b/man/shadowsocks-libev.8
@@ -92,7 +92,7 @@ Set the socket timeout in seconds. The default value is 60.
 .B \-c \fIconfig_file\fP
 Use a configuration file.
 .TP
-.B \-n \fInofile\fP
+.B \-n \fInumber\fP
 Specify max number of open files.
 
 Only available on Linux.

--- a/man/shadowsocks-libev.8
+++ b/man/shadowsocks-libev.8
@@ -120,6 +120,9 @@ Not available in local mode.
 .B \-A
 Enable onetime authentication.
 .TP
+.B \-w
+Enable white list mode (when ACL enabled).
+.TP
 .B \-L \fIaddr\fR:\fIport\fP
 Specify destination server address and port for local port forwarding.
 

--- a/man/ss-local.1
+++ b/man/ss-local.1
@@ -75,7 +75,7 @@ not work.
 Start shadowsocks as a daemon with specific pid file.
 .TP
 .B \-t \fItimeout\fP
-Set the socket timeout in seconds. The default value is 10.
+Set the socket timeout in seconds. The default value is 60.
 .TP
 .B \-c \fIconfig_file\fP
 Use a configuration file.

--- a/man/ss-local.1
+++ b/man/ss-local.1
@@ -71,6 +71,9 @@ chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
 If built with PolarSSL or custom OpenSSL libraries, some of these ciphers may
 not work.
 .TP
+.B \-a \fIuser_name\fP
+Run as a specific user.
+.TP
 .B \-f \fIpid_file\fP
 Start shadowsocks as a daemon with specific pid file.
 .TP
@@ -90,9 +93,6 @@ Specify network interface to bind.
 .TP
 .B \-b \fIlocal_address\fP
 Specify local address to bind.
-.TP
-.B \-a \fIuser_name\fP
-Run as a specific user.
 .TP
 .B \-u
 Enable UDP relay.

--- a/man/ss-local.1
+++ b/man/ss-local.1
@@ -43,7 +43,8 @@ shadowsocks created by clowwindy. \*(Me is written in pure C and takes advantage
 of \fBlibev\fP to achieve both high performance and low resource consumption.
 .PP
 \*(Me consists of five components. \*(Lo(1) works as a standard socks5 proxy
-on local machines to proxy TCP traffic. For more information, check out \fBshadowsocks-libev\fR(8).
+on local machines to proxy TCP traffic. For more information, check out
+\fBshadowsocks-libev\fR(8).
 
 .SH OPTIONS
 .TP
@@ -62,10 +63,10 @@ Set the password. The server and the client should use the same password.
 .B \-m \fIencrypt_method\fP
 Set the cipher.
 
-\*(Me accepts 18 different ciphers: table, rc4, rc4-md5,
-aes-128-cfb, aes-192-cfb, aes-256-cfb, bf-cfb, camellia-128-cfb,
-camellia-192-cfb, camellia-256-cfb, cast5-cfb, des-cfb, idea-cfb, rc2-cfb,
-seed-cfb, salsa20, chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
+\*(Me accepts 18 different ciphers: table, rc4, rc4-md5, aes-128-cfb,
+aes-192-cfb, aes-256-cfb, bf-cfb, camellia-128-cfb, camellia-192-cfb,
+camellia-256-cfb, cast5-cfb, des-cfb, idea-cfb, rc2-cfb, seed-cfb, salsa20,
+chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
 
 If built with PolarSSL or custom OpenSSL libraries, some of these ciphers may
 not work.
@@ -111,7 +112,8 @@ Enable ACL (Access Control List) and specify config file.
 Enable verbose mode.
 
 .SH EXAMPLE
-\*(Lo(1) can be started from command line and run in foreground. Here is an example:
+\*(Lo(1) can be started from command line and run in foreground. Here is an
+example:
 
     # Start ss-local with given parameters
     ss-local -s example.com -p 12345 -l 1080 -k foobar -m aes-256-cfb

--- a/man/ss-local.1
+++ b/man/ss-local.1
@@ -83,7 +83,7 @@ Set the socket timeout in seconds. The default value is 60.
 .B \-c \fIconfig_file\fP
 Use a configuration file.
 .TP
-.B \-n \fInofile\fP
+.B \-n \fInumber\fP
 Specify max number of open files.
 
 Only avaliable on Linux.

--- a/man/ss-local.1
+++ b/man/ss-local.1
@@ -1,7 +1,7 @@
 .ig
 . manual page for shadowsocks-libev
 .
-. Copyright (c) 2012-2015, by: Max Lv
+. Copyright (c) 2012-2016, by: Max Lv
 . All rights reserved.
 .
 . Permission is granted to copy, distribute and/or modify this document
@@ -25,7 +25,7 @@
 .ds Ma  \fBss-manager\fR
 .ds Me  \fBShadowsocks-libev\fR
 .
-.TH "SS-LOCAL" "1" "September 10, 2015" "SHADOWSOCKS-LIBEV"
+.TH "SS-LOCAL" "1" "April 19, 2016" "SHADOWSOCKS-LIBEV"
 .SH NAME
 ss-local \- shadowsocks client as socks5 proxy, libev port
 

--- a/man/ss-manager.1
+++ b/man/ss-manager.1
@@ -56,12 +56,6 @@ to the following \fBPROTOCOL\fR section.
 .B \-s \fIserver_host\fP
 Set the server's hostname or IP.
 .TP
-.B \-p \fIserver_port\fP
-Set the server's port number.
-.TP
-.B \-l \fIlocal_port\fP
-Set the local port number.
-.TP
 .B \-k \fIpassword\fP
 Set the password. The server and the client should use the same password.
 .TP
@@ -91,9 +85,6 @@ Use a configuration file.
 .B \-i \fIinterface\fP
 Specify network interface to bind.
 .TP
-.B \-b \fIlocal_address\fP
-Specify local address to bind.
-.TP
 .B \-u
 Enable UDP relay.
 .TP
@@ -102,6 +93,18 @@ Enable UDP relay and disable TCP relay.
 .TP
 .B \-A
 Enable onetime authentication.
+.TP
+.B \-d \fIaddr\fP
+Setup name servers for internal DNS resolver (libudns). The default server is
+fetched from /etc/resolv.conf.
+.TP
+.B \--fast-open
+Enable TCP fast open.
+
+Only available with Linux kernel > 3.7.0.
+.TP
+.B \--acl \fIacl_config\fP
+Enable ACL (Access Control List) and specify config file.
 .TP
 .B \--manager-address \fIpath_to_unix_domain\fP
 Specify UNIX domain socket address for the communication between \*(Ma(1) and

--- a/man/ss-manager.1
+++ b/man/ss-manager.1
@@ -76,6 +76,9 @@ chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
 If built with PolarSSL or custom OpenSSL libraries, some of these ciphers may
 not work.
 .TP
+.B \-a \fIuser_name\fP
+Run as a specific user.
+.TP
 .B \-f \fIpid_file\fP
 Start shadowsocks as a daemon with specific pid file.
 .TP
@@ -90,9 +93,6 @@ Specify network interface to bind.
 .TP
 .B \-b \fIlocal_address\fP
 Specify local address to bind.
-.TP
-.B \-a \fIuser_name\fP
-Run as a specific user.
 .TP
 .B \-u
 Enable UDP relay.

--- a/man/ss-manager.1
+++ b/man/ss-manager.1
@@ -27,7 +27,8 @@
 .
 .TH "SS-MANAGER" "1" "September 10, 2015" "SHADOWSOCKS-LIBEV"
 .SH NAME
-ss-manager \- ss-server controller for multi-user management and traffic statistics
+ss-manager \- ss-server controller for multi-user management and traffic
+statistics
 
 .SH SYNOPSIS
 \*(Ma
@@ -45,10 +46,10 @@ shadowsocks created by clowwindy. \*(Me is written in pure C and takes advantage
 of \fBlibev\fP to achieve both high performance and low resource consumption.
 .PP
 \*(Me consists of five components.
-\*(Ma(1) is a controller for multi-user management and traffic statistics, using UNIX
-domain socket to talk with \*(Se(1). Also, it provides a UNIX domain socket or IP based
-API for other software. About the details of this API, please refer to the following
-\fBPROTOCOL\fR section.
+\*(Ma(1) is a controller for multi-user management and traffic statistics, using
+UNIX domain socket to talk with \*(Se(1). Also, it provides a UNIX domain socket
+or IP based API for other software. About the details of this API, please refer
+to the following \fBPROTOCOL\fR section.
 
 .SH OPTIONS
 .TP
@@ -67,10 +68,10 @@ Set the password. The server and the client should use the same password.
 .B \-m \fIencrypt_method\fP
 Set the cipher.
 
-\*(Me accepts 18 different ciphers: table, rc4, rc4-md5,
-aes-128-cfb, aes-192-cfb, aes-256-cfb, bf-cfb, camellia-128-cfb,
-camellia-192-cfb, camellia-256-cfb, cast5-cfb, des-cfb, idea-cfb, rc2-cfb,
-seed-cfb, salsa20, chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
+\*(Me accepts 18 different ciphers: table, rc4, rc4-md5, aes-128-cfb,
+aes-192-cfb, aes-256-cfb, bf-cfb, camellia-128-cfb, camellia-192-cfb,
+camellia-256-cfb, cast5-cfb, des-cfb, idea-cfb, rc2-cfb, seed-cfb, salsa20,
+chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
 
 If built with PolarSSL or custom OpenSSL libraries, some of these ciphers may
 not work.
@@ -119,25 +120,27 @@ Enable verbose mode.
 .SH PROTOCOL
 \*(Ma(1) provides several APIs through UDP protocol:
 
-    Send UDP commands in the following format to the manager-address provided to \*(Ma(1).
+.in +4n
+Send UDP commands in the following format to the manager-address provided to
+\*(Ma(1).
 
-        command: [JSON data]
+    command: [JSON data]
 
-    To add a port:
+To add a port:
 
-        add: {"server_port": 8001, "password":"7cd308cc059"}
+    add: {"server_port": 8001, "password":"7cd308cc059"}
 
-    To remove a port:
+To remove a port:
 
-        remove: {"server_port": 8001}
+    remove: {"server_port": 8001}
 
-    To receive a pong:
+To receive a pong:
 
-        ping
+    ping
 
-    Then \*(Ma(1) will send back the traffic statistics:
+Then \*(Ma(1) will send back the traffic statistics:
 
-        stat: {"8001":11370}
+    stat: {"8001":11370}
 
 .SH EXAMPLE
 To use \*(Ma(1), First start it and specify necessary information.

--- a/man/ss-manager.1
+++ b/man/ss-manager.1
@@ -80,7 +80,7 @@ not work.
 Start shadowsocks as a daemon with specific pid file.
 .TP
 .B \-t \fItimeout\fP
-Set the socket timeout in seconds. The default value is 10.
+Set the socket timeout in seconds. The default value is 60.
 .TP
 .B \-c \fIconfig_file\fP
 Use a configuration file.

--- a/man/ss-manager.1
+++ b/man/ss-manager.1
@@ -104,8 +104,8 @@ Enable UDP relay and disable TCP relay.
 Enable onetime authentication.
 .TP
 .B \--manager-address \fIpath_to_unix_domain\fP
-Specify UNIX domain socket address for the communication between ss-manager and
-ss-server.
+Specify UNIX domain socket address for the communication between \*(Ma(1) and
+\*(Se(1).
 
 Only available in server and manager mode.
 .TP

--- a/man/ss-manager.1
+++ b/man/ss-manager.1
@@ -1,7 +1,7 @@
 .ig
 . manual page for shadowsocks-libev
 .
-. Copyright (c) 2012-2015, by: Max Lv
+. Copyright (c) 2012-2016, by: Max Lv
 . All rights reserved.
 .
 . Permission is granted to copy, distribute and/or modify this document
@@ -25,7 +25,7 @@
 .ds Ma  \fBss-manager\fR
 .ds Me  \fBShadowsocks-libev\fR
 .
-.TH "SS-MANAGER" "1" "September 10, 2015" "SHADOWSOCKS-LIBEV"
+.TH "SS-MANAGER" "1" "April 19, 2016" "SHADOWSOCKS-LIBEV"
 .SH NAME
 ss-manager \- ss-server controller for multi-user management and traffic
 statistics

--- a/man/ss-redir.1
+++ b/man/ss-redir.1
@@ -72,6 +72,9 @@ chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
 If built with PolarSSL or custom OpenSSL libraries, some of these ciphers may
 not work.
 .TP
+.B \-a \fIuser_name\fP
+Run as a specific user.
+.TP
 .B \-f \fIpid_file\fP
 Start shadowsocks as a daemon with specific pid file.
 .TP
@@ -88,9 +91,6 @@ Only avaliable on Linux.
 .TP
 .B \-b \fIlocal_address\fP
 Specify local address to bind.
-.TP
-.B \-a \fIuser_name\fP
-Run as a specific user.
 .TP
 .B \-u
 Enable UDP relay.

--- a/man/ss-redir.1
+++ b/man/ss-redir.1
@@ -1,7 +1,7 @@
 .ig
 . manual page for shadowsocks-libev
 .
-. Copyright (c) 2012-2015, by: Max Lv
+. Copyright (c) 2012-2016, by: Max Lv
 . All rights reserved.
 .
 . Permission is granted to copy, distribute and/or modify this document
@@ -25,7 +25,7 @@
 .ds Ma  \fBss-manager\fR
 .ds Me  \fBShadowsocks-libev\fR
 .
-.TH "SS-REDIR" "1" "September 10, 2015" "SHADOWSOCKS-LIBEV"
+.TH "SS-REDIR" "1" "April 19, 2016" "SHADOWSOCKS-LIBEV"
 .SH NAME
 ss-redir \- shadowsocks client as transparent proxy, libev port
 

--- a/man/ss-redir.1
+++ b/man/ss-redir.1
@@ -84,7 +84,7 @@ Set the socket timeout in seconds. The default value is 60.
 .B \-c \fIconfig_file\fP
 Use a configuration file.
 .TP
-.B \-n \fInofile\fP
+.B \-n \fInumber\fP
 Specify max number of open files.
 
 Only avaliable on Linux.

--- a/man/ss-redir.1
+++ b/man/ss-redir.1
@@ -42,10 +42,10 @@ ss-redir \- shadowsocks client as transparent proxy, libev port
 shadowsocks created by clowwindy. \*(Me is written in pure C and takes advantage
 of \fBlibev\fP to achieve both high performance and low resource consumption.
 .PP
-\*(Me consists of five components. \*(Re(1) works as a transparent proxy on local
-machines to proxy TCP traffic and requires netfilter's NAT module. For more
-information, check out \fBshadowsocks-libev\fR(8) and the following \fBEXAMPLE\fR
-section.
+\*(Me consists of five components. \*(Re(1) works as a transparent proxy on
+local machines to proxy TCP traffic and requires netfilter's NAT module. For
+more information, check out \fBshadowsocks-libev\fR(8) and the following
+\fBEXAMPLE\fR section.
 
 .SH OPTIONS
 .TP
@@ -64,10 +64,10 @@ Set the password. The server and the client should use the same password.
 .B \-m \fIencrypt_method\fP
 Set the cipher.
 
-\*(Me accepts 18 different ciphers: table, rc4, rc4-md5,
-aes-128-cfb, aes-192-cfb, aes-256-cfb, bf-cfb, camellia-128-cfb,
-camellia-192-cfb, camellia-256-cfb, cast5-cfb, des-cfb, idea-cfb, rc2-cfb,
-seed-cfb, salsa20, chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
+\*(Me accepts 18 different ciphers: table, rc4, rc4-md5, aes-128-cfb,
+aes-192-cfb, aes-256-cfb, bf-cfb, camellia-128-cfb, camellia-192-cfb,
+camellia-256-cfb, cast5-cfb, des-cfb, idea-cfb, rc2-cfb, seed-cfb, salsa20,
+chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
 
 If built with PolarSSL or custom OpenSSL libraries, some of these ciphers may
 not work.
@@ -94,6 +94,7 @@ Run as a specific user.
 .TP
 .B \-u
 Enable UDP relay.
+
 TPROXY is required in redir mode.
 .TP
 .B \-U
@@ -108,6 +109,7 @@ Enable verbose mode.
 .SH EXAMPLE
 \*(Re requires netfilter's NAT function. Here is an example:
 
+.nf
     # Create new chain
     root@Wrt:~# iptables -t nat -N SHADOWSOCKS
 
@@ -141,6 +143,7 @@ Enable verbose mode.
 
     # Start the shadowsocks-redir
     root@Wrt:~# ss-redir -u -c /etc/config/shadowsocks.json -f /var/run/shadowsocks.pid
+.fi
 
 .SH SEE ALSO
 .BR \*(Lo (1),

--- a/man/ss-redir.1
+++ b/man/ss-redir.1
@@ -76,7 +76,7 @@ not work.
 Start shadowsocks as a daemon with specific pid file.
 .TP
 .B \-t \fItimeout\fP
-Set the socket timeout in seconds. The default value is 10.
+Set the socket timeout in seconds. The default value is 60.
 .TP
 .B \-c \fIconfig_file\fP
 Use a configuration file.

--- a/man/ss-server.1
+++ b/man/ss-server.1
@@ -1,7 +1,7 @@
 .ig
 . manual page for shadowsocks-libev
 .
-. Copyright (c) 2012-2015, by: Max Lv
+. Copyright (c) 2012-2016, by: Max Lv
 . All rights reserved.
 .
 . Permission is granted to copy, distribute and/or modify this document
@@ -25,7 +25,7 @@
 .ds Ma  \fBss-manager\fR
 .ds Me  \fBShadowsocks-libev\fR
 .
-.TH "SS-SERVER" "1" "September 10, 2015" "SHADOWSOCKS-LIBEV"
+.TH "SS-SERVER" "1" "April 19, 2016" "SHADOWSOCKS-LIBEV"
 .SH NAME
 ss-server \- shadowsocks server, libev port
 

--- a/man/ss-server.1
+++ b/man/ss-server.1
@@ -115,8 +115,8 @@ Only available with Linux kernel > 3.7.0.
 Enable ACL (Access Control List) and specify config file.
 .TP
 .B \--manager-address \fIpath_to_unix_domain\fP
-Specify UNIX domain socket address for the communication between ss-manager and
-ss-server.
+Specify UNIX domain socket address for the communication between \*(Ma(1) and
+\*(Se(1).
 
 Only available in server and manager mode.
 .TP
@@ -133,9 +133,9 @@ ALSO\fR section for the default path of config file.
     ss-server -c /etc/shadowsocks-libev/config.json
 
 .SH BUGS
-The config file of shadowsocks-libev is slightly different from original
-shadowsocks. In order to listen to both IPv4/IPv6 address, use the following
-grammar in your config json file:
+The config file of \fBshadowsocks-libev\fR(8) is slightly different from
+original shadowsocks. In order to listen to both IPv4/IPv6 address, use the
+following grammar in your config json file:
 
     {
         "server":["[::0]","0.0.0.0"],

--- a/man/ss-server.1
+++ b/man/ss-server.1
@@ -73,6 +73,9 @@ chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
 If built with PolarSSL or custom OpenSSL libraries, some of these ciphers may
 not work.
 .TP
+.B \-a \fIuser_name\fP
+Run as a specific user.
+.TP
 .B \-f \fIpid_file\fP
 Start shadowsocks as a daemon with specific pid file.
 .TP
@@ -89,9 +92,6 @@ Only avaliable on Linux.
 .TP
 .B \-i \fIinterface\fP
 Specify network interface to bind.
-.TP
-.B \-a \fIuser_name\fP
-Run as a specific user.
 .TP
 .B \-u
 Enable UDP relay.

--- a/man/ss-server.1
+++ b/man/ss-server.1
@@ -85,7 +85,7 @@ Set the socket timeout in seconds. The default value is 60.
 .B \-c \fIconfig_file\fP
 Use a configuration file.
 .TP
-.B \-n \fInofile\fP
+.B \-n \fInumber\fP
 Specify max number of open files.
 
 Only avaliable on Linux.

--- a/man/ss-server.1
+++ b/man/ss-server.1
@@ -77,7 +77,7 @@ not work.
 Start shadowsocks as a daemon with specific pid file.
 .TP
 .B \-t \fItimeout\fP
-Set the socket timeout in seconds. The default value is 10.
+Set the socket timeout in seconds. The default value is 60.
 .TP
 .B \-c \fIconfig_file\fP
 Use a configuration file.

--- a/man/ss-server.1
+++ b/man/ss-server.1
@@ -102,6 +102,9 @@ Enable UDP relay and disable TCP relay.
 .B \-A
 Enable onetime authentication.
 .TP
+.B \-w
+Enable white list mode (when ACL enabled).
+.TP
 .B \-d \fIaddr\fP
 Setup name servers for internal DNS resolver (libudns). The default server is
 fetched from /etc/resolv.conf.

--- a/man/ss-server.1
+++ b/man/ss-server.1
@@ -56,9 +56,6 @@ Set the server's hostname or IP.
 .B \-p \fIserver_port\fP
 Set the server's port number.
 .TP
-.B \-l \fIlocal_port\fP
-Set the local port number.
-.TP
 .B \-k \fIpassword\fP
 Set the password. The server and the client should use the same password.
 .TP

--- a/man/ss-server.1
+++ b/man/ss-server.1
@@ -45,7 +45,8 @@ shadowsocks created by clowwindy. \*(Me is written in pure C and takes advantage
 of \fBlibev\fP to achieve both high performance and low resource consumption.
 .PP
 \*(Me consists of five components. \*(Se(1) runs on a remote server to provide
-secured tunnel service. For more information, check out \fBshadowsocks-libev\fR(8).
+secured tunnel service. For more information, check out
+\fBshadowsocks-libev\fR(8).
 
 .SH OPTIONS
 .TP
@@ -64,10 +65,10 @@ Set the password. The server and the client should use the same password.
 .B \-m \fIencrypt_method\fP
 Set the cipher.
 
-\*(Me accepts 18 different ciphers: table, rc4, rc4-md5,
-aes-128-cfb, aes-192-cfb, aes-256-cfb, bf-cfb, camellia-128-cfb,
-camellia-192-cfb, camellia-256-cfb, cast5-cfb, des-cfb, idea-cfb, rc2-cfb,
-seed-cfb, salsa20, chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
+\*(Me accepts 18 different ciphers: table, rc4, rc4-md5, aes-128-cfb,
+aes-192-cfb, aes-256-cfb, bf-cfb, camellia-128-cfb, camellia-192-cfb,
+camellia-256-cfb, cast5-cfb, des-cfb, idea-cfb, rc2-cfb, seed-cfb, salsa20,
+chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
 
 If built with PolarSSL or custom OpenSSL libraries, some of these ciphers may
 not work.
@@ -102,8 +103,8 @@ Enable UDP relay and disable TCP relay.
 Enable onetime authentication.
 .TP
 .B \-d \fIaddr\fP
-Setup name servers for internal DNS resolver (libudns). The default server
-is fetched from /etc/resolv.conf.
+Setup name servers for internal DNS resolver (libudns). The default server is
+fetched from /etc/resolv.conf.
 .TP
 .B \--fast-open
 Enable TCP fast open.
@@ -124,15 +125,16 @@ Enable verbose mode.
 
 .SH EXAMPLE
 It is recommended to use a config file when starting \*(Se(1).
-The config file is written in JSON and is easy to edit. Check out the
-\fBSEE ALSO\fR section for the default path of config file.
+
+The config file is written in JSON and is easy to edit. Check out the \fBSEE
+ALSO\fR section for the default path of config file.
 
     # Start the ss-server
     ss-server -c /etc/shadowsocks-libev/config.json
 
 .SH BUGS
 The config file of shadowsocks-libev is slightly different from original
-shadowsocks. In order to listen to both ipv4/ipv6 address, use the following
+shadowsocks. In order to listen to both IPv4/IPv6 address, use the following
 grammar in your config json file:
 
     {

--- a/man/ss-tunnel.1
+++ b/man/ss-tunnel.1
@@ -1,7 +1,7 @@
 .ig
 . manual page for shadowsocks-libev
 .
-. Copyright (c) 2012-2015, by: Max Lv
+. Copyright (c) 2012-2016, by: Max Lv
 . All rights reserved.
 .
 . Permission is granted to copy, distribute and/or modify this document
@@ -25,7 +25,7 @@
 .ds Ma  \fBss-manager\fR
 .ds Me  \fBShadowsocks-libev\fR
 .
-.TH "SS-TUNNEL" "1" "September 10, 2015" "SHADOWSOCKS-LIBEV"
+.TH "SS-TUNNEL" "1" "April 19, 2016" "SHADOWSOCKS-LIBEV"
 .SH NAME
 ss-tunnel \- shadowsocks tools for local port forwarding, libev port
 

--- a/man/ss-tunnel.1
+++ b/man/ss-tunnel.1
@@ -44,8 +44,8 @@ shadowsocks created by clowwindy. \*(Me is written in pure C and takes advantage
 of \fBlibev\fP to achieve both high performance and low resource consumption.
 .PP
 \*(Me consists of five components. \*(Tu(1) is a tool for local port forwarding.
-See \fBOPTIONS\fR section for special option needed by \*(Tu(1).
-For more information, check out \fBshadowsocks-libev\fR(8).
+See \fBOPTIONS\fR section for special option needed by \*(Tu(1). For more
+information, check out \fBshadowsocks-libev\fR(8).
 
 .SH OPTIONS
 .TP
@@ -64,10 +64,10 @@ Set the password. The server and the client should use the same password.
 .B \-m \fIencrypt_method\fP
 Set the cipher.
 
-\*(Me accepts 18 different ciphers: table, rc4, rc4-md5,
-aes-128-cfb, aes-192-cfb, aes-256-cfb, bf-cfb, camellia-128-cfb,
-camellia-192-cfb, camellia-256-cfb, cast5-cfb, des-cfb, idea-cfb, rc2-cfb,
-seed-cfb, salsa20, chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
+\*(Me accepts 18 different ciphers: table, rc4, rc4-md5, aes-128-cfb,
+aes-192-cfb, aes-256-cfb, bf-cfb, camellia-128-cfb, camellia-192-cfb,
+camellia-256-cfb, cast5-cfb, des-cfb, idea-cfb, rc2-cfb, seed-cfb, salsa20,
+chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
 
 If built with PolarSSL or custom OpenSSL libraries, some of these ciphers may
 not work.

--- a/man/ss-tunnel.1
+++ b/man/ss-tunnel.1
@@ -84,7 +84,7 @@ Set the socket timeout in seconds. The default value is 60.
 .B \-c \fIconfig_file\fP
 Use a configuration file.
 .TP
-.B \-n \fInofile\fP
+.B \-n \fInumber\fP
 Specify max number of open files.
 
 Only avaliable on Linux.

--- a/man/ss-tunnel.1
+++ b/man/ss-tunnel.1
@@ -76,7 +76,7 @@ not work.
 Start shadowsocks as a daemon with specific pid file.
 .TP
 .B \-t \fItimeout\fP
-Set the socket timeout in seconds. The default value is 10.
+Set the socket timeout in seconds. The default value is 60.
 .TP
 .B \-c \fIconfig_file\fP
 Use a configuration file.

--- a/man/ss-tunnel.1
+++ b/man/ss-tunnel.1
@@ -72,6 +72,9 @@ chacha20 and chacha20-ietf. The default cipher is \fItable\fP.
 If built with PolarSSL or custom OpenSSL libraries, some of these ciphers may
 not work.
 .TP
+.B \-a \fIuser_name\fP
+Run as a specific user.
+.TP
 .B \-f \fIpid_file\fP
 Start shadowsocks as a daemon with specific pid file.
 .TP
@@ -91,9 +94,6 @@ Specify network interface to bind.
 .TP
 .B \-b \fIlocal_address\fP
 Specify local address to bind.
-.TP
-.B \-a \fIuser_name\fP
-Run as a specific user.
 .TP
 .B \-u
 Enable UDP relay.


### PR DESCRIPTION
- added option '-w'
- added -d, --fast-open, --acl into ss-manager's man page
- removed -l from ss-server's man page
- removed -p, -l, -b from ss-manager's man page
- changed '-n nofile' => '-n number' for read easy
- fixed default timeout value (10 => 60)
- fixed 80 char width