### PR TITLE
fixed FATAL() to print user friendly error message

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -179,9 +179,10 @@ char *ss_strndup(const char *s, size_t n)
     return ret;
 }
 
-void FATAL(const char *msg)
+void FATAL(const char *s)
 {
-    LOGE("%s", msg);
+    char *msg = strerror(errno);
+    LOGE("%s: %s", s, msg);
     exit(-1);
 }
 


### PR DESCRIPTION
Fixed FATAL() to print user friendly error message, rather than just print "it's error".