### PR TITLE
fixed ipv6 address format in log message

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -468,7 +468,10 @@ static void server_recv_cb(EV_P_ ev_io *w, int revents)
                 }
 
                 if (verbose) {
-                    LOGI("connect to %s:%s", host, port);
+                    if (request->atyp == 4)
+                        LOGI("connect to [%s]:%s", host, port);
+                    else
+                        LOGI("connect to %s:%s", host, port);
                 }
 
                 if ((acl && (request->atyp == 1 || request->atyp == 4) && acl_match_ip(host))) {

--- a/src/server.c
+++ b/src/server.c
@@ -759,7 +759,10 @@ static void server_recv_cb(EV_P_ ev_io *w, int revents)
         }
 
         if (verbose) {
-            LOGI("connect to: %s:%d", host, ntohs(port));
+            if ((atyp & ADDRTYPE_MASK) == 4)
+                LOGI("connect to [%s]:%d", host, ntohs(port));
+            else
+                LOGI("connect to %s:%d", host, ntohs(port));
         }
 
         if (server->auth && !ss_check_hash(server->buf, server->chunk, server->d_ctx, BUF_SIZE)) {


### PR DESCRIPTION
before,
``` yyyy-mm-dd HH:MM:SS INFO: connect to 2001:b28:f23f:f005::a:443```
after fixed,
``` yyyy-mm-dd HH:MM:SS INFO: connect to [2001:b28:f23f:f005::a]:443```