### PR TITLE
Fix typo in source code

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,31 +28,31 @@ endif
 ss_local_SOURCES = utils.c \
                    jconf.c \
                    json.c \
-				   encrypt.c \
-				   udprelay.c \
-				   cache.c \
-				   acl.c \
-				   netutils.c \
-				   local.c
+                   encrypt.c \
+                   udprelay.c \
+                   cache.c \
+                   acl.c \
+                   netutils.c \
+                   local.c
 
 ss_tunnel_SOURCES = utils.c \
-					jconf.c \
-					json.c \
-					encrypt.c \
-					udprelay.c \
-					cache.c \
-					netutils.c \
-					tunnel.c
-
-ss_server_SOURCES = utils.c \
-					netutils.c \
                     jconf.c \
                     json.c \
                     encrypt.c \
-					udprelay.c \
-					cache.c \
-					acl.c \
-					resolv.c \
+                    udprelay.c \
+                    cache.c \
+                    netutils.c \
+                    tunnel.c
+
+ss_server_SOURCES = utils.c \
+                    netutils.c \
+                    jconf.c \
+                    json.c \
+                    encrypt.c \
+                    udprelay.c \
+                    cache.c \
+                    acl.c \
+                    resolv.c \
                     server.c
 
 ss_manager_SOURCES = utils.c \
@@ -91,9 +91,9 @@ ss_redir_SOURCES = utils.c \
                    jconf.c \
                    json.c \
                    encrypt.c \
-				   netutils.c \
-				   cache.c \
-				   udprelay.c \
+                   netutils.c \
+                   cache.c \
+                   udprelay.c \
                    redir.c
 ss_redir_CFLAGS = $(AM_CFLAGS) -DMODULE_REDIR
 ss_redir_LDADD = $(SS_COMMON_LIBS)

--- a/src/cache.h
+++ b/src/cache.h
@@ -1,5 +1,5 @@
 /*
- * cache.c - Define the cache manager interface
+ * cache.h - Define the cache manager interface
  *
  * Copyright (C) 2013 - 2016, Max Lv <max.c.lv@gmail.com>
  *

--- a/src/jconf.h
+++ b/src/jconf.h
@@ -1,5 +1,5 @@
 /*
- * server.c - Define the config data structure
+ * jconf.h - Define the config data structure
  *
  * Copyright (C) 2013 - 2016, Max Lv <max.c.lv@gmail.com>
  *

--- a/src/local.h
+++ b/src/local.h
@@ -1,5 +1,5 @@
 /*
- * local.h - Define the clinet's buffers and callbacks
+ * local.h - Define the client's buffers and callbacks
  *
  * Copyright (C) 2013 - 2016, Max Lv <max.c.lv@gmail.com>
  *

--- a/src/win32.h
+++ b/src/win32.h
@@ -1,5 +1,5 @@
 /*
- * win32.c - Win32 port helpers
+ * win32.h - Win32 port helpers
  *
  * Copyright (C) 2014, Linus Yang <linusyang@gmail.com>
  *


### PR DESCRIPTION
Including inconsistency in `src/Makefile.am` and minor typo in comments.