### PR TITLE
Another fix for #668 to solve dependency problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ debian/shadowsocks-libev.substvars
 debian/*.debhelper*
 .dirstamp
 shadowsocks-libev.pc
-debian/libshadowsocks1.symbols
+debian/libshadowsocks-libev1.symbols
 libsodium/src/libsodium/include/sodium/version.h
 
 # Ignore garbage of OS X

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,4 +1,4 @@
 *.substvars
-libshadowsocks1/
-libshadowsocks-dev/
+libshadowsocks-libev1/
+libshadowsocks-libev-dev/
 tmp/

--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,7 @@ Architecture: any
 Section: libdevel
 Priority: extra
 Breaks: shadowsocks-libev (<< 2.4.0)
-Depends: libshadowsocks1 (= ${binary:Version}), ${misc:Depends}
+Depends: libshadowsocks-libev1 (= ${binary:Version}), ${misc:Depends}
 Description: lightweight and secure socks5 proxy (development files)
  Shadowsocks-libev is a lightweight and secure socks5 proxy for
  embedded devices and low end boxes.


### PR DESCRIPTION
`libshadowsocks-libev-dev` should depend on `libshadowsocks-libev1`, not `libshadowsocks1`.