### PR TITLE
Add a signal SIGUSR1 for safely stop the server

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -940,6 +940,9 @@ static void signal_cb(EV_P_ ev_signal *w, int revents)
         switch (w->signum) {
         case SIGINT:
         case SIGTERM:
+#ifndef __MINGW32__
+        case SIGUSR1:
+#endif
             ev_unloop(EV_A_ EVUNLOOP_ALL);
         }
     }
@@ -1328,6 +1331,11 @@ int start_ss_local_server(profile_t profile)
     ev_signal_init(&sigterm_watcher, signal_cb, SIGTERM);
     ev_signal_start(EV_DEFAULT, &sigint_watcher);
     ev_signal_start(EV_DEFAULT, &sigterm_watcher);
+#ifndef __MINGW32__
+    struct ev_signal sigusr1_watcher;
+    ev_signal_init(&sigusr1_watcher, signal_cb, SIGUSR1);
+    ev_signal_start(EV_DEFAULT, &sigusr1_watcher);
+#endif
 
     // Setup keys
     LOGI("initializing ciphers... %s", method);
@@ -1405,6 +1413,9 @@ int start_ss_local_server(profile_t profile)
 
     ev_signal_stop(EV_DEFAULT, &sigint_watcher);
     ev_signal_stop(EV_DEFAULT, &sigterm_watcher);
+#ifndef __MINGW32__
+    ev_signal_stop(EV_DEFAULT, &sigusr1_watcher);
+#endif
 
     // cannot reach here
     return 0;

--- a/src/shadowsocks.h
+++ b/src/shadowsocks.h
@@ -83,5 +83,7 @@ int start_ss_local_server(profile_t profile);
 
 // To stop the service on posix system, just kill the daemon process
 // kill(pid, SIGKILL);
+// Otherwise, If you start the service in a thread, you may need to send a signal SIGUSER1 to the thread.
+// pthread_kill(pthread_t, SIGUSR1);
 
 #endif // _SHADOWSOCKS_H


### PR DESCRIPTION
Added a signal SIGUSER1 as parent thread can stop the server by sending this signal. 
This operation is thread-safe which require in ShadowsocksX-NG, a MAC OS X version port.

Reference:
https://github.com/cs17899219/ShadowsocksX-NG/blob/develop/ShadowsocksX-NG/SSLocalManager.c