### PR TITLE
fix path typo in debian/postinstall

### DIFF
--- a/debian/shadowsocks-libev.postinst
+++ b/debian/shadowsocks-libev.postinst
@@ -16,7 +16,7 @@ case "$1" in
 esac
 
 passwd=$(apg -n 1 -M ncl)
-sed -i "s/barfoo!/$passwd/" etc/shadowsocks-libev/config.json
+sed -i "s/barfoo!/$passwd/" /etc/shadowsocks-libev/config.json
 
 #DEBHELPER#
 


### PR DESCRIPTION
Missing slash causes dpkg -i to fail:
```
Setting up shadowsocks-libev (2.4.7-1) ...
sed: can't read etc/shadowsocks-libev/config.json: No such file or directory
dpkg: error processing shadowsocks-libev (--install):
 subprocess installed post-installation script returned error exit status 2
```