### PR TITLE
relicense manpages to GFDL with no invariant sections

### DIFF
--- a/man/shadowsocks-libev.8
+++ b/man/shadowsocks-libev.8
@@ -7,14 +7,10 @@
 . Permission is granted to copy, distribute and/or modify this document
 . under the terms of the GNU Free Documentation License, Version 1.1 or
 . any later version published by the Free Software Foundation;
-. with no Front-Cover Texts, no Back-Cover Texts, and with the following
-. Invariant Sections (and any sub-sections therein):
-.   all .ig sections, including this one
-.   STUPID TRICKS Sampler
-.   AUTHOR
+. with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
 .
-. A copy of the Free Documentation License is included in the section
-. entitled "GNU Free Documentation License".
+. A copy of the license is included in the section entitled
+. "GNU Free Documentation License".
 .
 ..
 \#                          - these two are for chuckles, makes great grammar

--- a/man/ss-local.1
+++ b/man/ss-local.1
@@ -7,14 +7,10 @@
 . Permission is granted to copy, distribute and/or modify this document
 . under the terms of the GNU Free Documentation License, Version 1.1 or
 . any later version published by the Free Software Foundation;
-. with no Front-Cover Texts, no Back-Cover Texts, and with the following
-. Invariant Sections (and any sub-sections therein):
-.   all .ig sections, including this one
-.   STUPID TRICKS Sampler
-.   AUTHOR
+. with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
 .
-. A copy of the Free Documentation License is included in the section
-. entitled "GNU Free Documentation License".
+. A copy of the license is included in the section entitled
+. "GNU Free Documentation License".
 .
 ..
 \#                          - these two are for chuckles, makes great grammar

--- a/man/ss-manager.1
+++ b/man/ss-manager.1
@@ -7,14 +7,10 @@
 . Permission is granted to copy, distribute and/or modify this document
 . under the terms of the GNU Free Documentation License, Version 1.1 or
 . any later version published by the Free Software Foundation;
-. with no Front-Cover Texts, no Back-Cover Texts, and with the following
-. Invariant Sections (and any sub-sections therein):
-.   all .ig sections, including this one
-.   STUPID TRICKS Sampler
-.   AUTHOR
+. with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
 .
-. A copy of the Free Documentation License is included in the section
-. entitled "GNU Free Documentation License".
+. A copy of the license is included in the section entitled
+. "GNU Free Documentation License".
 .
 ..
 \#                          - these two are for chuckles, makes great grammar

--- a/man/ss-nat.1
+++ b/man/ss-nat.1
@@ -7,14 +7,10 @@
 . Permission is granted to copy, distribute and/or modify this document
 . under the terms of the GNU Free Documentation License, Version 1.1 or
 . any later version published by the Free Software Foundation;
-. with no Front-Cover Texts, no Back-Cover Texts, and with the following
-. Invariant Sections (and any sub-sections therein):
-.   all .ig sections, including this one
-.   STUPID TRICKS Sampler
-.   AUTHOR
+. with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
 .
-. A copy of the Free Documentation License is included in the section
-. entitled "GNU Free Documentation License".
+. A copy of the license is included in the section entitled
+. "GNU Free Documentation License".
 .
 ..
 \#                          - these two are for chuckles, makes great grammar

--- a/man/ss-redir.1
+++ b/man/ss-redir.1
@@ -7,14 +7,10 @@
 . Permission is granted to copy, distribute and/or modify this document
 . under the terms of the GNU Free Documentation License, Version 1.1 or
 . any later version published by the Free Software Foundation;
-. with no Front-Cover Texts, no Back-Cover Texts, and with the following
-. Invariant Sections (and any sub-sections therein):
-.   all .ig sections, including this one
-.   STUPID TRICKS Sampler
-.   AUTHOR
+. with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
 .
-. A copy of the Free Documentation License is included in the section
-. entitled "GNU Free Documentation License".
+. A copy of the license is included in the section entitled
+. "GNU Free Documentation License".
 .
 ..
 \#                          - these two are for chuckles, makes great grammar

--- a/man/ss-server.1
+++ b/man/ss-server.1
@@ -7,14 +7,10 @@
 . Permission is granted to copy, distribute and/or modify this document
 . under the terms of the GNU Free Documentation License, Version 1.1 or
 . any later version published by the Free Software Foundation;
-. with no Front-Cover Texts, no Back-Cover Texts, and with the following
-. Invariant Sections (and any sub-sections therein):
-.   all .ig sections, including this one
-.   STUPID TRICKS Sampler
-.   AUTHOR
+. with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
 .
-. A copy of the Free Documentation License is included in the section
-. entitled "GNU Free Documentation License".
+. A copy of the license is included in the section entitled
+. "GNU Free Documentation License".
 .
 ..
 \#                          - these two are for chuckles, makes great grammar

--- a/man/ss-tunnel.1
+++ b/man/ss-tunnel.1
@@ -7,14 +7,10 @@
 . Permission is granted to copy, distribute and/or modify this document
 . under the terms of the GNU Free Documentation License, Version 1.1 or
 . any later version published by the Free Software Foundation;
-. with no Front-Cover Texts, no Back-Cover Texts, and with the following
-. Invariant Sections (and any sub-sections therein):
-.   all .ig sections, including this one
-.   STUPID TRICKS Sampler
-.   AUTHOR
+. with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
 .
-. A copy of the Free Documentation License is included in the section
-. entitled "GNU Free Documentation License".
+. A copy of the license is included in the section entitled
+. "GNU Free Documentation License".
 .
 ..
 \#                          - these two are for chuckles, makes great grammar


### PR DESCRIPTION
Make license of man pages to DFSG-free, according to:
 - https://wiki.debian.org/DFSGLicenses
 - https://wiki.debian.org/qa.debian.org/gfdlinvariant