### PR TITLE
New jconf parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ shadowsocks-libev.pc
 debian/libshadowsocks-libev1.symbols
 libsodium/src/libsodium/include/sodium/version.h
 
+# Ignore per-project vim config
+.vimrc
+
 # Ignore garbage of OS X
 *.DS_Store
 

--- a/src/common.h
+++ b/src/common.h
@@ -49,10 +49,6 @@
 #define SOL_TCP IPPROTO_TCP
 #endif
 
-#define TCP_ONLY     0
-#define TCP_AND_UDP  1
-#define UDP_ONLY     3
-
 #if defined(MODULE_TUNNEL) || defined(MODULE_REDIR)
 #define MODULE_LOCAL
 #endif

--- a/src/jconf.c
+++ b/src/jconf.c
@@ -193,6 +193,19 @@ jconf_t *read_jconf(const char *file)
                 conf.nameserver = to_string(value);
             } else if (strcmp(name, "tunnel_address") == 0) {
                 conf.tunnel_address = to_string(value);
+            } else if (strcmp(name, "mode") == 0) {
+                char *mode_str = to_string(value);
+
+                if (strcmp(mode_str, "tcp_only") == 0)
+                    conf.mode = TCP_ONLY;
+                else if (strcmp(mode_str, "tcp_and_udp") == 0)
+                    conf.mode = TCP_AND_UDP;
+                else if (strcmp(mode_str, "udp_only") == 0)
+                    conf.mode = UDP_ONLY;
+                else
+                    LOGI("ignore unknown mode: %s, use tcp_only as fallback",
+                         mode_str);
+                free(mode_str);
             }
         }
     } else {

--- a/src/jconf.c
+++ b/src/jconf.c
@@ -191,6 +191,8 @@ jconf_t *read_jconf(const char *file)
                 conf.nofile = value->u.integer;
             } else if (strcmp(name, "nameserver") == 0) {
                 conf.nameserver = to_string(value);
+            } else if (strcmp(name, "tunnel_address") == 0) {
+                conf.tunnel_address = to_string(value);
             }
         }
     } else {

--- a/src/jconf.h
+++ b/src/jconf.h
@@ -54,6 +54,7 @@ typedef struct {
     int fast_open;
     int nofile;
     char *nameserver;
+    char *tunnel_address;
 } jconf_t;
 
 jconf_t *read_jconf(const char *file);

--- a/src/jconf.h
+++ b/src/jconf.h
@@ -29,6 +29,11 @@
 #define MAX_CONNECT_TIMEOUT 10
 #define MIN_UDP_TIMEOUT 10
 
+#define TCP_ONLY     0
+#define TCP_AND_UDP  1
+#define UDP_ONLY     3
+
+
 typedef struct {
     char *host;
     char *port;
@@ -55,6 +60,7 @@ typedef struct {
     int nofile;
     char *nameserver;
     char *tunnel_address;
+    int mode;
 } jconf_t;
 
 jconf_t *read_jconf(const char *file);

--- a/src/local.c
+++ b/src/local.c
@@ -1137,6 +1137,12 @@ int main(int argc, char **argv)
         if (fast_open == 0) {
             fast_open = conf->fast_open;
         }
+        if (mode == TCP_ONLY) {
+            if (conf->mode == UDP_ONLY)
+                LOGI("ignore unsupported mode: udp_only, use tcp_only as fallback");
+            else
+                mode = conf->mode;
+        }
 #ifdef HAVE_SETRLIMIT
         if (nofile == 0) {
             nofile = conf->nofile;

--- a/src/manager.c
+++ b/src/manager.c
@@ -703,6 +703,9 @@ int main(int argc, char **argv)
         if (auth == 0) {
             auth = conf->auth;
         }
+        if (mode == TCP_ONLY) {
+            mode = conf->mode;
+        }
     }
 
     if (server_num == 0) {

--- a/src/server.c
+++ b/src/server.c
@@ -1485,6 +1485,9 @@ int main(int argc, char **argv)
         if (auth == 0) {
             auth = conf->auth;
         }
+        if (mode == TCP_ONLY) {
+            mode = conf->mode;
+        }
 #ifdef TCP_FASTOPEN
         if (fast_open == 0) {
             fast_open = conf->fast_open;

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -846,6 +846,9 @@ int main(int argc, char **argv)
         if (tunnel_addr_str == NULL) {
             tunnel_addr_str = conf->tunnel_address;
         }
+        if (mode == TCP_ONLY) {
+            mode = conf->mode;
+        }
 #ifdef HAVE_SETRLIMIT
         if (nofile == 0) {
             nofile = conf->nofile;

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -843,6 +843,9 @@ int main(int argc, char **argv)
         if (auth == 0) {
             auth = conf->auth;
         }
+        if (tunnel_addr_str == NULL) {
+            tunnel_addr_str = conf->tunnel_address;
+        }
 #ifdef HAVE_SETRLIMIT
         if (nofile == 0) {
             nofile = conf->nofile;


### PR DESCRIPTION
Add some new jconf parameters:

jconf name | valid values | equivalent 
---------- | -------------- | ----------
tunnel_address | socket address | "-L" of ss-tunnel |
mode |  "tcp_only", "tcp_and_udp" or "udp_only" | "-U" and "-u" options of server/tunnel/manager |

With these new jconfs, ss-tunnel can work with json config files, without using command line parameters


And add project vimrc to gitignore, as the coding indent is quite different from kernel.
