### PR TITLE
Fix dependency error

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ section below.
 ``` bash
 cd shadowsocks-libev
 sudo apt-get install build-essential autoconf libtool libssl-dev \
-    gawk debhelper dh-systemd init-system-helpers pkg-config asciidoc xmlto
+    gawk debhelper dh-systemd init-system-helpers pkg-config asciidoc xmlto apg asciidoc
 dpkg-buildpackage -b -us -uc -i
 cd ..
 sudo dpkg -i shadowsocks-libev*.deb


### PR DESCRIPTION
Fix dependency error when compile the latest commit in Debian/Ubuntu.
asciidoc : command not found.