### PR TITLE
fix bugs with when ss-server bind_address enabled

### DIFF
--- a/src/netutils.c
+++ b/src/netutils.c
@@ -91,6 +91,7 @@ int bind_to_address(int socket_fd, const char *host)
     if (host != NULL) {
         struct cork_ip ip;
         struct sockaddr_storage storage;
+        memset(&storage, 0, sizeof(storage));
         if (cork_ip_init(&ip, host) != -1) {
             if (ip.version == 4) {
                 struct sockaddr_in *addr = (struct sockaddr_in *)&storage;

--- a/src/server.c
+++ b/src/server.c
@@ -415,6 +415,7 @@ static remote_t *connect_to_remote(struct addrinfo *res,
 #ifdef SO_NOSIGPIPE
     setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof(opt));
 #endif
+    setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
 
     remote_t *remote = new_remote(sockfd);
 


### PR DESCRIPTION
when I use ss-server  with "-b x.x.x.x", sometimes I got the below errors,
connect: cannot assign requested address
bind_to_address: Address already in use

try to fixed it