### PR TITLE
src/ss-nat should be excluded from rule src/ss-* in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ libtool
 pid
 ss.*
 src/ss-*
+!src/ss-nat
 stamp-h1
 .libs
 .pc


### PR DESCRIPTION
otherwise someone copy the repo from local computer and add to other repo as depend source , will encounter:
No rule to make target 'ss-nat', needed by 'all-am'.  Stop.

or someone has mod src/ss-nat , git can not detect the modify.

to reproduce this error:
git clone https://github.com/shadowsocks/shadowsocks-libev.git
cd my_exist_repo
cp -rv ../shadowsocks-libev ./
rm -rf ./shadowsocks-libev/.git
git add ./shadowsocks-libev  #now the src/ss-nat will silently be ignored ...