### PR TITLE
openwrt: disable documentation build by default

### DIFF
--- a/openwrt/Makefile
+++ b/openwrt/Makefile
@@ -56,7 +56,7 @@ define Package/shadowsocks-libev/conffiles
 /etc/shadowsocks.json
 endef
 
-CONFIGURE_ARGS += --disable-ssp
+CONFIGURE_ARGS += --disable-documentation --disable-ssp
 
 ifeq ($(BUILD_VARIANT),polarssl)
 	CONFIGURE_ARGS += --with-crypto-library=polarssl


### PR DESCRIPTION
Debloating asciidoc and xmlto makes life easier on OpenWrt/LEDE.

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>