### PR TITLE
 Show crypto library using in the help message

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -215,7 +215,7 @@ void
 usage()
 {
     printf("\n");
-    printf("shadowsocks-libev %s\n\n", VERSION);
+    printf("shadowsocks-libev %s with %s\n\n", VERSION, USING_CRYPTO);  
     printf(
         "  maintained by Max Lv <max.c.lv@gmail.com> and Linus Yang <laokongzi@gmail.com>\n\n");
     printf("  usage:\n\n");

--- a/src/utils.h
+++ b/src/utils.h
@@ -20,6 +20,21 @@
  * <http://www.gnu.org/licenses/>.
  */
 
+#if defined(USE_CRYPTO_OPENSSL)
+
+#include <openssl/opensslv.h>
+#define USING_CRYPTO OPENSSL_VERSION_TEXT
+
+#elif defined(USE_CRYPTO_POLARSSL)
+#include <polarssl/version.h>
+#define USING_CRYPTO POLARSSL_VERSION_STRING_FULL
+
+#elif defined(USE_CRYPTO_MBEDTLS)
+#include <mbedtls/version.h>
+#define USING_CRYPTO MBEDTLS_VERSION_STRING_FULL
+
+#endif
+
 #ifndef _UTILS_H
 #define _UTILS_H
 


### PR DESCRIPTION
It's help to identify statically compiled files. 

    $ ss-local -h

shadowsocks-libev 2.5.3 **with mbed TLS 2.2.1**
