### PR TITLE
Include shadowsocks-libev-*.service files for RPM package

### DIFF
--- a/rpm/SPECS/shadowsocks-libev.spec
+++ b/rpm/SPECS/shadowsocks-libev.spec
@@ -46,6 +46,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/default
 mkdir -p %{buildroot}%{_unitdir}
 install -m 644 %{_builddir}/%{buildsubdir}/debian/shadowsocks-libev.default %{buildroot}%{_sysconfdir}/default/shadowsocks-libev
 install -m 644 %{_builddir}/%{buildsubdir}/debian/shadowsocks-libev.service %{buildroot}%{_unitdir}/shadowsocks-libev.service
+install -m 644 %{_builddir}/%{buildsubdir}/debian/shadowsocks-libev-*.service %{buildroot}%{_unitdir}/
 %endif
 install -m 644 %{_builddir}/%{buildsubdir}/debian/config.json %{buildroot}%{_sysconfdir}/shadowsocks-libev/config.json
 
@@ -82,6 +83,7 @@ fi
 %{_initddir}/shadowsocks-libev
 %else
 %{_unitdir}/shadowsocks-libev.service
+%{_unitdir}/shadowsocks-libev-*.service
 %config(noreplace) %{_sysconfdir}/default/shadowsocks-libev
 %endif
 


### PR DESCRIPTION
Update SPEC file to install /debian/shadowsocks-libev-*.service files.