### PR TITLE
Fix missing dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,8 +58,10 @@ AC_ARG_ENABLE([documentation],
 AM_CONDITIONAL([ENABLE_DOCUMENTATION], [test x$disable_documentation = xfalse])
 
 AM_COND_IF([ENABLE_DOCUMENTATION], [
-  AC_PATH_PROG([ASCIIDOC], [asciidoc], [asciidoc])
-  AC_PATH_PROG([XMLTO], [xmlto], [xmlto])
+  AC_PATH_PROG([ASCIIDOC], [asciidoc])
+  test x"${ASCIIDOC}" != x || AC_MSG_ERROR([Cannot find `asciidoc` in PATH.]) 
+  AC_PATH_PROG([XMLTO], [xmlto])
+  test x"$XMLTO" != x || AC_MSG_ERROR([Cannot find `xmlto` in PATH.]) 
   AC_PATH_PROG([GZIP], [gzip], [gzip])
   AC_PATH_PROG([RM], [rm], [rm])
   AC_PATH_PROG([MV], [mv], [mv])

--- a/rpm/SPECS/shadowsocks-libev.spec.in
+++ b/rpm/SPECS/shadowsocks-libev.spec.in
@@ -8,7 +8,7 @@ License:	GPLv3+
 URL:		https://github.com/shadowsocks/%{name}
 Source0:	%{url}/archive/v%{version}.tar.gz
 
-BuildRequires:	openssl-devel
+BuildRequires: make automake gcc openssl-devel pcre-devel asciidoc xmlto
 Requires:	openssl
 
 %if 0%{?rhel} != 6


### PR DESCRIPTION
It seems to me that the spec file misses some build dependencies, such as `xmlto` and `asciidoc`.
I complemented them so that we can install all build dependencies by running `yum-builddep shadowsocks-libev.spec`.

Furthermore, I'd like to make `configure` procedure fail if those two package are missing.