### PR TITLE
Make genrpm.sh a little safer.

### DIFF
--- a/rpm/genrpm.sh
+++ b/rpm/genrpm.sh
@@ -38,28 +38,18 @@ do
     esac
 done
 
-get_att_val()
-{
-    att=$1
-    val=$2
-
-    if [ -z $(eval echo \$$att) ]; then
-        eval $att=$val
-    fi
-}
-
-get_att_val version "2.5.5"
-get_att_val format "tar.gz"
+: ${version:=2.5.5}
+: ${format:=tar.gz}
 
 name="shadowsocks-libev"
 spec_name="shadowsocks-libev.spec"
 
 pushd `git rev-parse --show-toplevel`
-git archive v${version} --format=${format} --prefix=${name}-${version}/ -o rpm/SOURCES/${name}-${version}.${format}
+git archive "v${version}" --format="${format}" --prefix="${name}-${version}/" -o rpm/SOURCES/"${name}-${version}.${format}"
 pushd rpm
 
 sed -e "s/^\(Version:	\).*$/\1${version}/" \
     -e "s/^\(Source0:	\).*$/\1${name}-${version}.${format}/" \
-    SPECS/${spec_name}.in > SPECS/${spec_name}
+    SPECS/"${spec_name}".in > SPECS/"${spec_name}"
 
-rpmbuild -bb SPECS/${spec_name} --define "%_topdir `pwd`"
+rpmbuild -bb SPECS/"${spec_name}" --define "%_topdir `pwd`"


### PR DESCRIPTION
1. Remove function `get_att_val`:
That function uses `eval` to set default values for bash variables.
Because it is very dangerous to use `eval` (someone call it the plague of shell scripting), I'd like to use the bash builtin to do that.
2. Double quote all variables to avoid unexpected expansion when using it.

BTW, the default version of `git` on EL6 is too old to support archive in `.tar.gz` command. Maybe we can change the default format to `tar`?