### PR TITLE
Remove -U option that disables TCP relay

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -56,6 +56,4 @@ CMD ss-server -s $SERVER_ADDR \
               --fast-open \
               -d $DNS_ADDR \
               -d $DNS_ADDR_2 \
-              -U \
               -u
-


### PR DESCRIPTION
According to [documentation](https://github.com/shadowsocks/shadowsocks-libev/blob/master/doc/ss-server.asciidoc) `-U` option enables UDP relay and disables TCP relay. 

TCP relay shouldn't be disabled by default, as it may mislead those who are referencing official Dockerfile.