### PR TITLE
Friendlize init message while listen on an IPv6 address.

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -1426,7 +1426,10 @@ main(int argc, char **argv)
                       get_sockaddr_len(listen_ctx.remote_addr[0]), mtu, m, auth, listen_ctx.timeout, iface);
     }
 
-    LOGI("listening at %s:%s", local_addr, local_port);
+    if (strcmp(local_addr, ":") > 0)
+        LOGI("listening at [%s]:%s", local_addr, local_port);
+    else
+        LOGI("listening at %s:%s", local_addr, local_port);
 
     // setuid
     if (user != NULL) {
@@ -1578,7 +1581,10 @@ start_ss_local_server(profile_t profile)
                       get_sockaddr_len(addr), mtu, m, auth, timeout, NULL);
     }
 
-    LOGI("listening at %s:%s", local_addr, local_port_str);
+    if (strcmp(local_addr, ":") > 0)
+        LOGI("listening at [%s]:%s", local_addr, local_port_str);
+    else
+        LOGI("listening at %s:%s", local_addr, local_port_str);
 
     // Init connections
     cork_dllist_init(&connections);


### PR DESCRIPTION
Before,

```bash
$ ss-local -s::1 -p8388 -b::1 -l1080 -k123456 -v
 ...
 2016-10-25 20:07:03 INFO: listening at ::1:1080
 ...
```

After,

```bash
$ ss-local -s::1 -p8388 -b::1 -l1080 -k123456 -v
 ...
 2016-10-25 20:07:49 INFO: listening at [::1]:1080
 ...
```