### PR TITLE
support ipv6_first option in config file

### DIFF
--- a/doc/shadowsocks-libev.asciidoc
+++ b/doc/shadowsocks-libev.asciidoc
@@ -160,12 +160,13 @@ The config file equivalent of command line options is listed as example below.
 | -s some.server.net -p 1234 (client) | "server": "some.server.net:1234"
 | -p 1234 -k "PasSworD" (server)      | "port_password": {"1234":"PasSworD"}
 | -p 1234                             | "server_port": "1234"
-| -b 0.0.0.0                          | "local_adress": "0.0.0.0"
+| -b 0.0.0.0                          | "local_address": "0.0.0.0"
 | -l 4321                             | "local_port": "4321"
 | -k "PasSworD"                       | "password": "PasSworD"
 | -m "aes-256-cfb"                    | "method": "aes-256-cfb"
 | -t 60                               | "timeout": 60
 | --fast-open                         | "fast_open": true
+| -6                                  | "ipv6_first": true
 | -A                                  | "auth": true
 | -n "/etc/nofile"                    | "nofile": "/etc/nofile"
 | -d "8.8.8.8"                        | "nameserver": "8.8.8.8"

--- a/src/jconf.c
+++ b/src/jconf.c
@@ -216,6 +216,8 @@ read_jconf(const char *file)
                 conf.mtu = value->u.integer;
             } else if (strcmp(name, "mptcp") == 0) {
                 conf.mptcp = value->u.boolean;
+            } else if (strcmp(name, "ipv6_first") == 0) {
+                conf.ipv6_first = value->u.boolean;
             }
         }
     } else {

--- a/src/jconf.h
+++ b/src/jconf.h
@@ -63,6 +63,7 @@ typedef struct {
     int mode;
     int mtu;
     int mptcp;
+    int ipv6_first;
 } jconf_t;
 
 jconf_t *read_jconf(const char *file);

--- a/src/server.c
+++ b/src/server.c
@@ -1715,6 +1715,9 @@ main(int argc, char **argv)
         if (conf->nameserver != NULL) {
             nameservers[nameserver_num++] = conf->nameserver;
         }
+        if (ipv6first == 0) {
+            ipv6first = conf->ipv6_first;
+        }
     }
 
     if (server_num == 0) {


### PR DESCRIPTION
I'm very glad to see that ss-server not supports `-6` option in the command line to prefer IPv6 traffic on the server side.
Would you consider adding `ipv6_first` option to the config file? This patch may help.
Thanks.