### PR TITLE
fix permission check on operating iptables

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -130,7 +130,11 @@ init_firewall()
     if (pclose(fp) == 0) {
         mode = FIREWALLD_MODE;
     } else {
-        sprintf(cli, "iptables --version 2>&1");
+        /* Check whether we have permission to operate iptables. 
+	 * Note that checking `iptables --version` is insufficient:
+         * eg, running within a child user namespace.
+	 */
+        sprintf(cli, "iptables -L 2>&1");
         fp = popen(cli, "r");
         if (fp == NULL)
             return -1;


### PR DESCRIPTION
Using `iptables --version` to perform permission check on operating iptables is insufficient.
For example, running in a child Linux user namespace or in a Docker container.
Let's just simply use `iptables -L` instead.
 