### PR TITLE
exit if attempting run as nonexistent user and warn if running as root

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -1440,8 +1440,11 @@ main(int argc, char **argv)
         LOGI("listening at %s:%s", local_addr, local_port);
 
     // setuid
-    if (user != NULL) {
-        run_as(user);
+    if (user != NULL && ! run_as(user)) {
+        FATAL("failed to switch user");
+    }
+    if (geteuid() == 0){
+        LOGI("You are running this process as the root user!");
     }
 
     // Init connections

--- a/src/manager.c
+++ b/src/manager.c
@@ -845,11 +845,14 @@ main(int argc, char **argv)
     struct ev_loop *loop = EV_DEFAULT;
 
     // setuid
-    if (user != NULL) {
-        run_as(user);
+    if (user != NULL && ! run_as(user)) {
+        FATAL("failed to switch user");
+    }
+    if (geteuid() == 0){
+        LOGI("You are running this process as the root user!");
     }
 
-    struct passwd *pw   = getpwuid(getuid());
+    struct passwd *pw   = getpwuid(geteuid());
     const char *homedir = pw->pw_dir;
     working_dir_size = strlen(homedir) + 15;
     working_dir      = malloc(working_dir_size);

--- a/src/redir.c
+++ b/src/redir.c
@@ -1021,8 +1021,11 @@ main(int argc, char **argv)
     LOGI("listening at %s:%s", local_addr, local_port);
 
     // setuid
-    if (user != NULL) {
-        run_as(user);
+    if (user != NULL && ! run_as(user)) {
+        FATAL("failed to switch user");
+    }
+    if (geteuid() == 0){
+        LOGI("You are running this process as the root user!");
     }
 
     ev_run(loop, 0);

--- a/src/server.c
+++ b/src/server.c
@@ -1871,8 +1871,11 @@ main(int argc, char **argv)
     ev_timer_start(EV_DEFAULT, &block_list_watcher);
 
     // setuid
-    if (user != NULL) {
-        run_as(user);
+    if (user != NULL && ! run_as(user)) {
+        FATAL("failed to switch user");
+    }
+    if (geteuid() == 0){
+        LOGI("You are running this process as the root user!");
     }
 
     // init block list

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1028,8 +1028,11 @@ main(int argc, char **argv)
     LOGI("listening at %s:%s", local_addr, local_port);
 
     // setuid
-    if (user != NULL) {
-        run_as(user);
+    if (user != NULL && ! run_as(user)) {
+        FATAL("failed to switch user");
+    }
+    if (geteuid() == 0){
+        LOGI("You are running this process as the root user!");
     }
 
     ev_run(loop, 0);


### PR DESCRIPTION
For security reasons we may abort execution if specified running user does not exist (or it will run as root unexpectedly).
And warn users if running as root.