### PR TITLE
Fix broken `configure --enable-system-shared-lib`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,6 @@ AM_COND_IF([ENABLE_DOCUMENTATION], [
   AC_PATH_PROG([XMLTO], [xmlto])
   test x"$XMLTO" != x || AC_MSG_ERROR([Cannot find `xmlto` in PATH.]) 
   AC_PATH_PROG([GZIP], [gzip], [gzip])
-  AC_PATH_PROG([RM], [rm], [rm])
   AC_PATH_PROG([MV], [mv], [mv])
   AC_PROG_SED
 ])


### PR DESCRIPTION
The following error will occur when configuring with --enable-system-shared-lib:

```
/usr/bin/rm: cannot remove 'libtoolT': No such file or directory
```

This issue is caused by overwriting gnu make variable `RM` with `rm`,
whose default value is `rm -f` (https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html).