### PR TITLE
RPM packaing: move .la, .so  to devel subpackage

### DIFF
--- a/rpm/SPECS/shadowsocks-libev.spec.in
+++ b/rpm/SPECS/shadowsocks-libev.spec.in
@@ -83,7 +83,8 @@ fi
 /usr/share/doc/shadowsocks-libev/ss-server.html
 /usr/share/doc/shadowsocks-libev/ss-tunnel.html
 %{_bindir}/*
-%{_libdir}/*
+%{_libdir}/*.so.*
+%{_libdir}/pkgconfig/*.pc
 %config(noreplace) %{_sysconfdir}/shadowsocks-libev/config.json
 %doc %{_mandir}/*
 %if 0%{?rhel} == 6
@@ -98,12 +99,15 @@ fi
 Summary:    Development files for shadowsocks-libev
 Group:      Applications/Internet
 License:    GPLv3+
+Requires:   shadowsocks-libev == %{version}-%{release}
 
 %description devel
 Development files for shadowsocks-libev
 
 %files devel
 %{_includedir}/*
+%{_libdir}/libshadowsocks-libev.la
+%{_libdir}/libshadowsocks-libev.so
 
 %changelog
 


### PR DESCRIPTION
Traditionally, `*.la` and `*.so` should go towards `*-devel` package while `*.so.VERSION` should go towards the main package, even if `*.so` in current version is almost useless :smile: 