### PR TITLE
Fix issues found by cppcheck

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -243,7 +243,7 @@ json_parse_ex(json_settings *settings,
               char *error_buf)
 {
     json_char error[json_error_max];
-    unsigned int cur_line;
+    int cur_line;
     const json_char *cur_line_begin, *i, *end;
     json_value *top, *root, *alloc = 0;
     json_state state = { 0UL, 0U, 0UL, { 0UL, 0, NULL, NULL, NULL }, 0 };

--- a/src/local.c
+++ b/src/local.c
@@ -744,7 +744,7 @@ stat_update_cb()
 static void
 remote_timeout_cb(EV_P_ ev_timer *watcher, int revents)
 {
-    remote_ctx_t *remote_ctx = (remote_ctx_t *)(((void *)watcher)
+    remote_ctx_t *remote_ctx = (remote_ctx_t *)(((char *)watcher)
                                                 - sizeof(ev_io));
     remote_t *remote = remote_ctx->remote;
     server_t *server = remote->server;
@@ -1565,9 +1565,10 @@ start_ss_local_server(profile_t profile)
     // Setup proxy context
     struct ev_loop *loop = EV_DEFAULT;
 
+    struct sockaddr **remote_addr_tmp = ss_malloc(sizeof(struct sockaddr *));
     listen_ctx_t listen_ctx;
     listen_ctx.remote_num     = 1;
-    listen_ctx.remote_addr    = ss_malloc(sizeof(struct sockaddr *));
+    listen_ctx.remote_addr    = remote_addr_tmp;
     listen_ctx.remote_addr[0] = (struct sockaddr *)storage;
     listen_ctx.timeout        = timeout;
     listen_ctx.method         = m;
@@ -1629,7 +1630,7 @@ start_ss_local_server(profile_t profile)
     }
 
     ss_free(listen_ctx.remote_addr[0]);
-    ss_free(listen_ctx.remote_addr);
+    ss_free(remote_addr_tmp);
 
 #ifdef __MINGW32__
     winsock_cleanup();

--- a/src/redir.c
+++ b/src/redir.c
@@ -220,7 +220,7 @@ server_recv_cb(EV_P_ ev_io *w, int revents)
             port = ntohs(sa->sin6_port);
         }
 
-        LOGI("redir to %s:%d, len=%zd, recv=%zd", ipstr, port, remote->buf->len, r);
+        LOGI("redir to %s:%d, len=%zu, recv=%zd", ipstr, port, remote->buf->len, r);
     }
 
     if (auth) {
@@ -328,7 +328,7 @@ server_send_cb(EV_P_ ev_io *w, int revents)
 static void
 remote_timeout_cb(EV_P_ ev_timer *watcher, int revents)
 {
-    remote_ctx_t *remote_ctx = (remote_ctx_t *)(((void *)watcher)
+    remote_ctx_t *remote_ctx = (remote_ctx_t *)(((char *)watcher)
                                                 - sizeof(ev_io));
     remote_t *remote = remote_ctx->remote;
     server_t *server = remote->server;

--- a/src/server.c
+++ b/src/server.c
@@ -529,7 +529,7 @@ connect_to_remote(EV_P_ struct addrinfo *res,
             ERROR("bind_to_address");
             close(sockfd);
             return NULL;
-        } 
+        }
 
 #ifdef SET_INTERFACE
     if (iface) {
@@ -542,7 +542,7 @@ connect_to_remote(EV_P_ struct addrinfo *res,
 #endif
 
     remote_t *remote = new_remote(sockfd);
-  
+
 #ifdef TCP_FASTOPEN
     if (fast_open) {
 #ifdef __APPLE__
@@ -1049,7 +1049,7 @@ block_list_clear_cb(EV_P_ ev_timer *watcher, int revents)
 static void
 server_timeout_cb(EV_P_ ev_timer *watcher, int revents)
 {
-    server_ctx_t *server_ctx = (server_ctx_t *)(((void *)watcher)
+    server_ctx_t *server_ctx = (server_ctx_t *)(((char *)watcher)
                                                 - sizeof(ev_io));
     server_t *server = server_ctx->server;
     remote_t *remote = server->remote;

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -284,7 +284,7 @@ server_send_cb(EV_P_ ev_io *w, int revents)
 static void
 remote_timeout_cb(EV_P_ ev_timer *watcher, int revents)
 {
-    remote_ctx_t *remote_ctx = (remote_ctx_t *)(((void *)watcher)
+    remote_ctx_t *remote_ctx = (remote_ctx_t *)(((char *)watcher)
                                                 - sizeof(ev_io));
     remote_t *remote = remote_ctx->remote;
     server_t *server = remote->server;

--- a/src/udprelay.c
+++ b/src/udprelay.c
@@ -549,7 +549,7 @@ close_and_free_remote(EV_P_ remote_ctx_t *ctx)
 static void
 remote_timeout_cb(EV_P_ ev_timer *watcher, int revents)
 {
-    remote_ctx_t *remote_ctx = (remote_ctx_t *)(((void *)watcher)
+    remote_ctx_t *remote_ctx = (remote_ctx_t *)(((char *)watcher)
                                                 - sizeof(ev_io));
 
     if (verbose) {


### PR DESCRIPTION
- GNU treats void* as char* when doing pointer arithmetic, so let's make it clear
- Fix memory leak, save copy from malloc() and pass the original pointer to free()
- minor type mismatches

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>