### PR TITLE
Fix include

### DIFF
--- a/src/obfs_http.c
+++ b/src/obfs_http.c
@@ -25,6 +25,7 @@
 #endif
 
 #include <strings.h>
+#include <time.h>
 
 #include "obfs_http.h"
 #include "base64.h"


### PR DESCRIPTION
I'm not sure if it's my setup that treats warnings as errors or something else, but without this it won't compile.