### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ e.g. Ubuntu, Debian or Linux Mint, you can build the binary like this:
 
 ```bash
 # Debian / Ubuntu
-sudo apt-get install --no-install-recommends build-essential autoconf libtool libssl-dev libpcre3-dev asciidoc xmlto
+sudo apt-get install --no-install-recommends build-essential autoconf libtool libssl-dev libpcre3-dev asciidoc xmlto zlib1g-dev
 # CentOS / Fedora / RHEL
 sudo yum install gcc autoconf libtool automake make zlib-devel openssl-devel asciidoc xmlto
 ./configure && make


### PR DESCRIPTION
Missing `zlib1g-dev` . On Debian 8.6, command `./configure` will fail and complain that `zlib.h` is not found