### PR TITLE
Check port before add port via ss-manager

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -72,6 +72,7 @@ ss_server_SOURCES = utils.c \
 ss_manager_SOURCES = utils.c \
                      jconf.c \
                      json.c \
+                     netutils.c \
                      manager.c
 
 ss_local_LDADD = $(SS_COMMON_LIBS)
@@ -82,10 +83,12 @@ if USE_SYSTEM_SHARED_LIB
 ss_local_LDADD += -ludns
 ss_tunnel_LDADD += -ludns
 ss_server_LDADD += -ludns
+ss_manager_LDADD += -ludns
 else
 ss_local_LDADD += $(top_builddir)/libudns/libudns.la
 ss_tunnel_LDADD += $(top_builddir)/libudns/libudns.la
 ss_server_LDADD += $(top_builddir)/libudns/libudns.la
+ss_manager_LDADD += $(top_builddir)/libudns/libudns.la
 endif
 
 ss_local_CFLAGS = $(AM_CFLAGS) -DMODULE_LOCAL

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -94,14 +94,16 @@ bin_PROGRAMS = ss-local$(EXEEXT) ss-tunnel$(EXEEXT) $(am__EXEEXT_1) \
 @USE_SYSTEM_SHARED_LIB_TRUE@am__append_5 = -ludns
 @USE_SYSTEM_SHARED_LIB_TRUE@am__append_6 = -ludns
 @USE_SYSTEM_SHARED_LIB_TRUE@am__append_7 = -ludns
-@USE_SYSTEM_SHARED_LIB_FALSE@am__append_8 = $(top_builddir)/libudns/libudns.la
+@USE_SYSTEM_SHARED_LIB_TRUE@am__append_8 = -ludns
 @USE_SYSTEM_SHARED_LIB_FALSE@am__append_9 = $(top_builddir)/libudns/libudns.la
 @USE_SYSTEM_SHARED_LIB_FALSE@am__append_10 = $(top_builddir)/libudns/libudns.la
-@BUILD_WINCOMPAT_TRUE@am__append_11 = win32.c
-@BUILD_WINCOMPAT_TRUE@am__append_12 = win32.c
-@BUILD_REDIRECTOR_TRUE@am__append_13 = ss-redir
-@BUILD_REDIRECTOR_TRUE@@USE_SYSTEM_SHARED_LIB_TRUE@am__append_14 = -ludns
-@BUILD_REDIRECTOR_TRUE@@USE_SYSTEM_SHARED_LIB_FALSE@am__append_15 = $(top_builddir)/libudns/libudns.la
+@USE_SYSTEM_SHARED_LIB_FALSE@am__append_11 = $(top_builddir)/libudns/libudns.la
+@USE_SYSTEM_SHARED_LIB_FALSE@am__append_12 = $(top_builddir)/libudns/libudns.la
+@BUILD_WINCOMPAT_TRUE@am__append_13 = win32.c
+@BUILD_WINCOMPAT_TRUE@am__append_14 = win32.c
+@BUILD_REDIRECTOR_TRUE@am__append_15 = ss-redir
+@BUILD_REDIRECTOR_TRUE@@USE_SYSTEM_SHARED_LIB_TRUE@am__append_16 = -ludns
+@BUILD_REDIRECTOR_TRUE@@USE_SYSTEM_SHARED_LIB_FALSE@am__append_17 = $(top_builddir)/libudns/libudns.la
 subdir = src
 DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
 	$(top_srcdir)/auto/depcomp $(include_HEADERS)
@@ -156,7 +158,7 @@ am__DEPENDENCIES_2 = $(top_builddir)/libipset/libipset.la \
 	$(top_builddir)/libcork/libcork.la $(am__DEPENDENCIES_1) \
 	$(am__DEPENDENCIES_1) $(am__append_3)
 am__DEPENDENCIES_3 = $(am__DEPENDENCIES_2) $(am__DEPENDENCIES_1) \
-	$(am__append_8)
+	$(am__append_9)
 libshadowsocks_libev_la_DEPENDENCIES = $(am__DEPENDENCIES_3)
 am__libshadowsocks_libev_la_SOURCES_DIST = utils.c jconf.c json.c \
 	encrypt.c udprelay.c cache.c acl.c netutils.c local.c \
@@ -209,15 +211,16 @@ am_ss_local_OBJECTS = ss_local-utils.$(OBJEXT) \
 	$(am__objects_5) $(am__objects_6) $(am__objects_7)
 ss_local_OBJECTS = $(am_ss_local_OBJECTS)
 ss_local_DEPENDENCIES = $(am__DEPENDENCIES_2) $(am__DEPENDENCIES_1) \
-	$(am__append_8)
+	$(am__append_9)
 ss_local_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(ss_local_CFLAGS) \
 	$(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
 am_ss_manager_OBJECTS = ss_manager-utils.$(OBJEXT) \
 	ss_manager-jconf.$(OBJEXT) ss_manager-json.$(OBJEXT) \
-	ss_manager-manager.$(OBJEXT)
+	ss_manager-netutils.$(OBJEXT) ss_manager-manager.$(OBJEXT)
 ss_manager_OBJECTS = $(am_ss_manager_OBJECTS)
-ss_manager_DEPENDENCIES = $(am__DEPENDENCIES_2)
+ss_manager_DEPENDENCIES = $(am__DEPENDENCIES_2) $(am__DEPENDENCIES_1) \
+	$(am__append_12)
 ss_manager_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(ss_manager_CFLAGS) \
 	$(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
@@ -239,7 +242,7 @@ am__objects_9 = ss_redir-http.$(OBJEXT) ss_redir-tls.$(OBJEXT) \
 @BUILD_REDIRECTOR_TRUE@	$(am__objects_8) $(am__objects_9)
 ss_redir_OBJECTS = $(am_ss_redir_OBJECTS)
 @BUILD_REDIRECTOR_TRUE@ss_redir_DEPENDENCIES = $(am__DEPENDENCIES_2) \
-@BUILD_REDIRECTOR_TRUE@	$(am__DEPENDENCIES_1) $(am__append_15)
+@BUILD_REDIRECTOR_TRUE@	$(am__DEPENDENCIES_1) $(am__append_17)
 ss_redir_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(ss_redir_CFLAGS) \
 	$(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
@@ -255,7 +258,7 @@ am_ss_server_OBJECTS = ss_server-utils.$(OBJEXT) \
 	ss_server-server.$(OBJEXT) $(am__objects_10) $(am__objects_11)
 ss_server_OBJECTS = $(am_ss_server_OBJECTS)
 ss_server_DEPENDENCIES = $(am__DEPENDENCIES_2) $(am__DEPENDENCIES_1) \
-	$(am__append_10)
+	$(am__append_11)
 ss_server_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(ss_server_CFLAGS) \
 	$(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
@@ -272,7 +275,7 @@ am_ss_tunnel_OBJECTS = ss_tunnel-utils.$(OBJEXT) \
 	$(am__objects_12) ss_tunnel-tunnel.$(OBJEXT) $(am__objects_13)
 ss_tunnel_OBJECTS = $(am_ss_tunnel_OBJECTS)
 ss_tunnel_DEPENDENCIES = $(am__DEPENDENCIES_2) $(am__DEPENDENCIES_1) \
-	$(am__append_9)
+	$(am__append_10)
 ss_tunnel_LINK = $(LIBTOOL) $(AM_V_lt) --tag=CC $(AM_LIBTOOLFLAGS) \
 	$(LIBTOOLFLAGS) --mode=link $(CCLD) $(ss_tunnel_CFLAGS) \
 	$(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
@@ -492,9 +495,9 @@ obfs_src = obfs_http.c \
 
 ss_local_SOURCES = utils.c jconf.c json.c encrypt.c udprelay.c cache.c \
 	acl.c netutils.c local.c $(obfs_src) $(sni_src) \
-	$(am__append_11)
+	$(am__append_13)
 ss_tunnel_SOURCES = utils.c jconf.c json.c encrypt.c udprelay.c \
-	cache.c netutils.c $(obfs_src) tunnel.c $(am__append_12)
+	cache.c netutils.c $(obfs_src) tunnel.c $(am__append_14)
 ss_server_SOURCES = utils.c \
                     netutils.c \
                     jconf.c \
@@ -511,12 +514,13 @@ ss_server_SOURCES = utils.c \
 ss_manager_SOURCES = utils.c \
                      jconf.c \
                      json.c \
+                     netutils.c \
                      manager.c
 
-ss_local_LDADD = $(SS_COMMON_LIBS) $(am__append_5) $(am__append_8)
-ss_tunnel_LDADD = $(SS_COMMON_LIBS) $(am__append_6) $(am__append_9)
-ss_server_LDADD = $(SS_COMMON_LIBS) $(am__append_7) $(am__append_10)
-ss_manager_LDADD = $(SS_COMMON_LIBS)
+ss_local_LDADD = $(SS_COMMON_LIBS) $(am__append_5) $(am__append_9)
+ss_tunnel_LDADD = $(SS_COMMON_LIBS) $(am__append_6) $(am__append_10)
+ss_server_LDADD = $(SS_COMMON_LIBS) $(am__append_7) $(am__append_11)
+ss_manager_LDADD = $(SS_COMMON_LIBS) $(am__append_8) $(am__append_12)
 ss_local_CFLAGS = $(AM_CFLAGS) -DMODULE_LOCAL
 ss_tunnel_CFLAGS = $(AM_CFLAGS) -DMODULE_TUNNEL
 ss_server_CFLAGS = $(AM_CFLAGS) -DMODULE_REMOTE
@@ -535,7 +539,7 @@ ss_manager_CFLAGS = $(AM_CFLAGS) -DMODULE_MANAGER
 
 @BUILD_REDIRECTOR_TRUE@ss_redir_CFLAGS = $(AM_CFLAGS) -DMODULE_REDIR
 @BUILD_REDIRECTOR_TRUE@ss_redir_LDADD = $(SS_COMMON_LIBS) \
-@BUILD_REDIRECTOR_TRUE@	$(am__append_14) $(am__append_15)
+@BUILD_REDIRECTOR_TRUE@	$(am__append_16) $(am__append_17)
 lib_LTLIBRARIES = libshadowsocks-libev.la
 libshadowsocks_libev_la_SOURCES = $(ss_local_SOURCES)
 libshadowsocks_libev_la_CFLAGS = $(ss_local_CFLAGS) -DLIB_ONLY
@@ -760,6 +764,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ss_manager-jconf.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ss_manager-json.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ss_manager-manager.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ss_manager-netutils.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ss_manager-utils.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ss_redir-base64.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ss_redir-cache.Po@am__quote@
@@ -1205,6 +1210,20 @@ ss_manager-json.obj: json.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='json.c' object='ss_manager-json.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ss_manager_CFLAGS) $(CFLAGS) -c -o ss_manager-json.obj `if test -f 'json.c'; then $(CYGPATH_W) 'json.c'; else $(CYGPATH_W) '$(srcdir)/json.c'; fi`
+
+ss_manager-netutils.o: netutils.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ss_manager_CFLAGS) $(CFLAGS) -MT ss_manager-netutils.o -MD -MP -MF $(DEPDIR)/ss_manager-netutils.Tpo -c -o ss_manager-netutils.o `test -f 'netutils.c' || echo '$(srcdir)/'`netutils.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/ss_manager-netutils.Tpo $(DEPDIR)/ss_manager-netutils.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='netutils.c' object='ss_manager-netutils.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ss_manager_CFLAGS) $(CFLAGS) -c -o ss_manager-netutils.o `test -f 'netutils.c' || echo '$(srcdir)/'`netutils.c
+
+ss_manager-netutils.obj: netutils.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ss_manager_CFLAGS) $(CFLAGS) -MT ss_manager-netutils.obj -MD -MP -MF $(DEPDIR)/ss_manager-netutils.Tpo -c -o ss_manager-netutils.obj `if test -f 'netutils.c'; then $(CYGPATH_W) 'netutils.c'; else $(CYGPATH_W) '$(srcdir)/netutils.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/ss_manager-netutils.Tpo $(DEPDIR)/ss_manager-netutils.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='netutils.c' object='ss_manager-netutils.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ss_manager_CFLAGS) $(CFLAGS) -c -o ss_manager-netutils.obj `if test -f 'netutils.c'; then $(CYGPATH_W) 'netutils.c'; else $(CYGPATH_W) '$(srcdir)/netutils.c'; fi`
 
 ss_manager-manager.o: manager.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(ss_manager_CFLAGS) $(CFLAGS) -MT ss_manager-manager.o -MD -MP -MF $(DEPDIR)/ss_manager-manager.Tpo -c -o ss_manager-manager.o `test -f 'manager.c' || echo '$(srcdir)/'`manager.c

--- a/src/manager.c
+++ b/src/manager.c
@@ -327,15 +327,7 @@ create_and_bind(const char *host, const char *port)
     hints.ai_flags    = AI_PASSIVE | AI_ADDRCONFIG; /* For wildcard IP address */
     hints.ai_protocol = IPPROTO_TCP;
 
-    for (int i = 1; i < 8; i++) {
-        s = getaddrinfo(host, port, &hints, &result);
-        if (s == 0) {
-            break;
-        } else {
-            sleep(pow(2, i));
-            LOGE("failed to resolve server name, wait %.0f seconds", pow(2, i));
-        }
-    }
+    s = getaddrinfo(host, port, &hints, &result);
 
     if (s != 0) {
         LOGE("getaddrinfo: %s", gai_strerror(s));

--- a/src/manager.c
+++ b/src/manager.c
@@ -1191,7 +1191,8 @@ main(int argc, char **argv)
     cork_hash_table_iterator_init(sock_table, &sock_iter);
 
     while ((entry = cork_hash_table_iterator_next(&sock_iter)) != NULL) {
-        // TODO close and release all remaining socks.
+        sock_lock_t *sock_lock = (sock_lock_t *)entry->value;
+        release_sock_lock(sock_lock);
     }
 
 #ifdef __MINGW32__

--- a/src/manager.c
+++ b/src/manager.c
@@ -435,6 +435,20 @@ release_sock_lock(sock_lock_t *sock_lock) {
 }
 
 static void
+get_and_release_sock_lock(char* port) {
+    if (verbose) {
+        LOGI("try to get and release sock lock at port: %s", port);
+    }
+
+    sock_lock_t *sock_lock = NULL;
+    bool ret = cork_hash_table_delete(sock_table, port, NULL, (void **)&sock_lock);
+
+    if (ret) {
+        release_sock_lock(sock_lock);
+    }
+}
+
+static void
 sock_lock_timeout_cb(EV_P_ ev_timer *watcher, int revents) {
     sock_lock_t *sock_lock = cork_container_of(watcher, sock_lock_t, watcher);
     
@@ -678,6 +692,7 @@ manager_recv_cb(EV_P_ ev_io *w, int revents)
         }
 
         update_stat(port, traffic);
+        get_and_release_sock_lock(port);
     } else if (strcmp(action, "ping") == 0) {
         struct cork_hash_table_entry *entry;
         struct cork_hash_table_iterator server_iter;

--- a/src/manager.h
+++ b/src/manager.h
@@ -64,8 +64,9 @@ struct server {
 };
 
 typedef struct sock_lock {
-    char *name;
-    int fd;
+    char *port;
+    int *fds;
+    int fd_count;
     ev_timer watcher;
 } sock_lock_t;
 

--- a/src/manager.h
+++ b/src/manager.h
@@ -63,4 +63,10 @@ struct server {
     uint64_t traffic;
 };
 
+typedef struct sock_lock {
+    char *name;
+    int fd;
+    ev_timer watcher;
+} sock_lock_t;
+
 #endif // _MANAGER_H


### PR DESCRIPTION
1. ss-manager will try to bind needed port to check its availability;

2. echo "ok" to normal request;

3. echo "port is not available" back when port used by other process.

I am not so farmiliar with pure c and libev, please point out anything improper and I will fix it soon.