### PR TITLE
Create SHADOWSOCKS_MARK in iptable rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ The latest shadowsocks-libev has provided a *redir* mode. You can configure your
     # Create new chain
     root@Wrt:~# iptables -t nat -N SHADOWSOCKS
     root@Wrt:~# iptables -t mangle -N SHADOWSOCKS
+    root@Wrt:~# iptables -t mangle -N SHADOWSOCKS_MARK
 
     # Ignore your shadowsocks server's addresses
     # It's very IMPORTANT, just be careful.


### PR DESCRIPTION
SHADOWSOCKS_MARK is used at line #405 and #410, but never created.