### PR TITLE
fix shared lib search path issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
     - git clone https://github.com/jedisct1/libsodium
     - pushd libsodium
     - ./autogen.sh
-    - ./configure && make
+    - ./configure --prefix=/usr && make
     - sudo make install
     - popd
 addons:


### PR DESCRIPTION
The shared lib file, libsodium.so, could not be found in default share object file path.

The default libsodium.git install files into /usr/local/lib, which is NOT found by system defaults.