### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -6,7 +6,6 @@ FROM alpine
 MAINTAINER kev <noreply@datageek.info>
 
 ARG SS_VER=2.6.3
-ARG SS_URL=https://github.com/shadowsocks/shadowsocks-libev/archive/v$SS_VER.tar.gz
 
 ENV SERVER_ADDR 0.0.0.0
 ENV SERVER_PORT 8388
@@ -18,12 +17,6 @@ ENV DNS_ADDR_2  8.8.4.4
 
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps \
-                                libev-dev \
-                                udns-dev \
-                                libsodium-dev \
-								gettext \
-								automake \
-								zlib \
                                 asciidoc \
                                 autoconf \
                                 build-base \
@@ -31,11 +24,19 @@ RUN set -ex && \
                                 libtool \
                                 linux-headers \
                                 openssl-dev \
+                                libev-dev \
+                                udns-dev \
+                                libsodium-dev \
+                                gettext \
+                                git \
                                 pcre-dev \
-                                tar \
+                                automake \
+                                zlib \
                                 xmlto && \
     cd /tmp && \
-    curl -sSL $SS_URL | tar xz --strip 1 && \
+    git clone --recursive https://github.com/shadowsocks/shadowsocks-libev.git && \
+    cd shadowsocks-libev && \
+    ./autogen.sh && \
     ./configure --prefix=/usr --disable-documentation && \
     make install && \
     cd .. && \


### PR DESCRIPTION
Update Dockerfile so that autogen.sh actually runs and generate the configure bash script. May use additional `git checkout tags/v$SS_VER && \` later for specific version since the current tag v2.6.3 still refuse to build correctly. The latest commit (as of Jan.25, 2017) builds okay.