### PR TITLE
Obfsproxy standalone mode

### DIFF
--- a/doc/ss-local.asciidoc
+++ b/doc/ss-local.asciidoc
@@ -14,7 +14,7 @@ SYNOPSIS
  [-t <timeout>] [-c <config_file>] [-i <interface>]
  [-a <user_name>] [-b <local_address] [-n <nofile>]
  [--fast-open] [--acl <acl_config>] [--mtu <MTU>]
- [--plugin <plugin_name>] [--plugin_opts <plugin_options]
+ [--plugin <plugin_name>] [--plugin-opts <plugin_options]
 
 DESCRIPTION
 -----------
@@ -119,7 +119,7 @@ Only available with MPTCP enabled Linux kernel.
 --plugin <plugin_name>::
 Enable SIP003 plugin. (Experimental)
 
---plugin_opts <plugin_options>::
+--plugin-opts <plugin_options>::
 Set SIP003 plugin options. (Experimental)
 
 -v::

--- a/doc/ss-manager.asciidoc
+++ b/doc/ss-manager.asciidoc
@@ -15,7 +15,7 @@ SYNOPSIS
  [-b <local_addr>] [-a <user_name>]
  [--manager-address <path_to_unix_domain>]
  [--executable <path_to_server_executable>]
- [--plugin <plugin_name>] [--plugin_opts <plugin_options>]
+ [--plugin <plugin_name>] [--plugin-opts <plugin_options>]
 
 DESCRIPTION
 -----------
@@ -109,7 +109,7 @@ Only available in manager mode.
 --plugin <plugin_name>::
 Enable SIP003 plugin. (Experimental)
 
---plugin_opts <plugin_options>::
+--plugin-opts <plugin_options>::
 Set SIP003 plugin options. (Experimental)
 
 -v::

--- a/doc/ss-redir.asciidoc
+++ b/doc/ss-redir.asciidoc
@@ -13,7 +13,7 @@ SYNOPSIS
  [-k <password>] [-m <encrypt_method>] [-f <pid_file>]
  [-t <timeout>] [-c <config_file>] [-b <local_address>]
  [-a <user_name>] [-n <nofile>] [--mtu <MTU>]
- [--plugin <plugin_name>] [--plugin_opts <plugin_options]
+ [--plugin <plugin_name>] [--plugin-opts <plugin_options]
 
 DESCRIPTION
 -----------
@@ -105,7 +105,7 @@ Only available with MPTCP enabled Linux kernel.
 --plugin <plugin_name>::
 Enable SIP003 plugin. (Experimental)
 
---plugin_opts <plugin_options>::
+--plugin-opts <plugin_options>::
 Set SIP003 plugin options. (Experimental)
 
 -v::

--- a/doc/ss-server.asciidoc
+++ b/doc/ss-server.asciidoc
@@ -16,7 +16,7 @@ SYNOPSIS
  [-b <local_address] [--fast-open] [--mptcp]
  [--acl <acl_config>] [--mtu <MTU>]
  [--manager-address <path_to_unix_domain>]
- [--plugin <plugin_name>] [--plugin_opts <plugin_options]
+ [--plugin <plugin_name>] [--plugin-opts <plugin_options]
 
 DESCRIPTION
 -----------
@@ -126,7 +126,7 @@ Only available with MPTCP enabled Linux kernel.
 --plugin <plugin_name>::
 Enable SIP003 plugin. (Experimental)
 
---plugin_opts <plugin_options>::
+--plugin-opts <plugin_options>::
 Set SIP003 plugin options. (Experimental)
 
 -v::

--- a/doc/ss-tunnel.asciidoc
+++ b/doc/ss-tunnel.asciidoc
@@ -14,7 +14,7 @@ SYNOPSIS
  [-t <timeout>] [-c <config_file>] [-i <interface>]
  [-b <local_addr>] [-a <user_name>] [-n <nofile>]
  [-L addr:port] [--mtu <MTU>]
- [--plugin <plugin_name>] [--plugin_opts <plugin_options]
+ [--plugin <plugin_name>] [--plugin-opts <plugin_options]
 
 DESCRIPTION
 -----------
@@ -116,7 +116,7 @@ Only available with MPTCP enabled Linux kernel.
 --plugin <plugin_name>::
 Enable SIP003 plugin. (Experimental)
 
---plugin_opts <plugin_options>::
+--plugin-opts <plugin_options>::
 Set SIP003 plugin options. (Experimental)
 
 -v::

--- a/src/local.c
+++ b/src/local.c
@@ -1453,7 +1453,7 @@ main(int argc, char **argv)
             len = strlen(remote_str);
         }
         int err = start_plugin(plugin, plugin_opts, remote_str,
-                remote_port, plugin_host, plugin_port);
+                remote_port, plugin_host, plugin_port, MODE_CLIENT);
         if (err) {
             FATAL("failed to start the plugin");
         }

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -84,7 +84,8 @@ start_plugin(const char *plugin,
              const char *remote_host,
              const char *remote_port,
              const char *local_host,
-             const char *local_port)
+             const char *local_port,
+             enum plugin_mode mode)
 {
     char *new_path = NULL;
     char *cmd      = NULL;

--- a/src/plugin.h
+++ b/src/plugin.h
@@ -27,12 +27,49 @@
 #define PLUGIN_EXIT_NORMAL -1
 #define PLUGIN_RUNNING      0
 
+enum plugin_mode {
+    MODE_CLIENT,
+    MODE_SERVER
+};
+
+/*
+ * XXX: Since we have SS plugins and obfsproxy support, for now we will
+ *      do extra check against the plugin name.
+ *      For obfsproxy, we will not follow the SS specified protocol and
+ *      do special routine for obfsproxy.
+ *      This may change when the protocol is finally settled
+ *
+ * Main function to start a plugin.
+ *
+ * @plugin: name of the plugin
+ *          search from PATH and current directory.
+ * @plugin_opts: Special options for plugin
+ * @remote_host:
+ *   CLIENT mode:
+ *     The remote server address, which also runs corresponding plugin
+ *   SERVER mode:
+ *     The real listen address, which plugin will listen to
+ * @remote_port:
+ *   CLIENT mode:
+ *     The remote server port, which corresponding plugin is listening to
+ *   SERVER mode:
+ *     The real listen port, which plugin will listen to
+ * @local_host:
+ *   Where ss-libev will connect/listen to.
+ *   Normally localhost for both modes.
+ * @local_port:
+ *   Where ss-libev will connect/listen to.
+ *   Internal user port.
+ * @mode:
+ *   Indicates which mode the plugin should run at.
+ */
 int start_plugin(const char *plugin,
                  const char *plugin_opts,
                  const char *remote_host,
                  const char *remote_port,
                  const char *local_host,
-                 const char *local_port);
+                 const char *local_port,
+                 enum plugin_mode mode);
 uint16_t get_local_port();
 void stop_plugin();
 int is_plugin_running();

--- a/src/redir.c
+++ b/src/redir.c
@@ -1028,7 +1028,7 @@ main(int argc, char **argv)
             len = strlen(remote_str);
         }
         int err = start_plugin(plugin, plugin_opts, remote_str,
-                remote_port, plugin_host, plugin_port);
+                remote_port, plugin_host, plugin_port, MODE_CLIENT);
         if (err) {
             FATAL("failed to start the plugin");
         }

--- a/src/server.c
+++ b/src/server.c
@@ -1884,7 +1884,7 @@ main(int argc, char **argv)
         }
 
         int err = start_plugin(plugin, plugin_opts, server_str,
-                plugin_port, "127.0.0.1", server_port);
+                plugin_port, "127.0.0.1", server_port, MODE_SERVER);
         if (err) {
             FATAL("failed to start the plugin");
         }

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1011,7 +1011,7 @@ main(int argc, char **argv)
             len = strlen(remote_str);
         }
         int err = start_plugin(plugin, plugin_opts, remote_str,
-                remote_port, plugin_host, plugin_port);
+                remote_port, plugin_host, plugin_port, MODE_CLIENT);
         if (err) {
             FATAL("failed to start the plugin");
         }


### PR DESCRIPTION
Now shadowsocks-libev should support obfsproxy standalone(proxy) mode now.

The overall idea is pretty simple and stupid, just run obfsproxy using given address/port.
Since we have standalone mode, no environment nor protocol is really needed, just make ss-server/local to listen/connect to a localhost port.
That's all.

I tested it with both obfs3 and screamblesuite(need extra --password) and they both work fine in my test environment.

I also fixed one doc bug, which for command line --plugin_opts is wrong, but --plugin-opts.

However, since this implementation needs to co-exist with the SS protocal one, I detect the plugin name and only when it's "obfsproxy" it will go through the obfsproxy parameter assembly routine.
For others plugin, it still follow the old SS_* environment way.

For me, it's quite ugly, far from elegent.
It may be improved after we implement full PT spec(need support for SOCKS5 proxy support), then we may be able to convert to full Tor PT implement.

But before that, we need to implement SOCKS5 proxy support first.

Thanks.