### PR TITLE
Update readme about libmbedtls and libsodium

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ section below.
 cd shadowsocks-libev
 sudo apt-get install --no-install-recommends gettext build-essential autoconf libtool \
     gawk debhelper dh-systemd init-system-helpers pkg-config asciidoc xmlto apg libpcre3-dev \
-    libev-dev libudns-dev
+    libev-dev libudns-dev dh-autoreconf
 ./autogen.sh && dpkg-buildpackage -b -us -uc -i
 cd ..
 sudo dpkg -i shadowsocks-libev*.deb

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ popd
 wget https://tls.mbed.org/download/mbedtls-$MBEDTLS_VER-gpl.tgz
 tar xvf mbedtls-$MBEDTLS_VER-gpl.tgz
 pushd mbedtls-$MBEDTLS_VER
+export SHARED=1
 make
 sudo make install
 popd
@@ -130,8 +131,8 @@ section below.
 ``` bash
 cd shadowsocks-libev
 sudo apt-get install --no-install-recommends gettext build-essential autoconf libtool \
-    gawk debhelper dh-systemd init-system-helpers pkg-config asciidoc xmlto apg libpcre3-dev libmbedtls-dev \
-    libev-dev libudns-dev libsodium-dev
+    gawk debhelper dh-systemd init-system-helpers pkg-config asciidoc xmlto apg libpcre3-dev \
+    libev-dev libudns-dev
 ./autogen.sh && dpkg-buildpackage -b -us -uc -i
 cd ..
 sudo dpkg -i shadowsocks-libev*.deb
@@ -163,7 +164,7 @@ If you are using CentOS 7, you need to install these prequirement to build from 
 
 ```bash 
 yum install epel-release -y
-yum install gcc gettext autoconf libtool automake make pcre-devel asciidoc xmlto udns-devel libev-devel libmbedtls-devel -y
+yum install gcc gettext autoconf libtool automake make pcre-devel asciidoc xmlto udns-devel libev-devel -y
 ```
 
 #### Install from repository
@@ -217,11 +218,11 @@ e.g. Ubuntu, Debian or Linux Mint, you can build the binary like this:
 
 ```bash
 # Debian / Ubuntu
-sudo apt-get install --no-install-recommends gettext build-essential autoconf libtool libpcre3-dev asciidoc xmlto libmbedtls-dev libev-dev libudns-dev libsodium-dev
+sudo apt-get install --no-install-recommends gettext build-essential autoconf libtool libpcre3-dev asciidoc xmlto libev-dev libudns-dev
 # CentOS / Fedora / RHEL
-sudo yum install gettext gcc autoconf libtool automake make libmbedtls-devel asciidoc xmlto udns-devel libev-devel
+sudo yum install gettext gcc autoconf libtool automake make asciidoc xmlto udns-devel libev-devel
 # Arch
-sudo pacman -S gettext gcc autoconf libtool automake make mbedtls asciidoc xmlto udns libev libsodium
+sudo pacman -S gettext gcc autoconf libtool automake make asciidoc xmlto udns libev
 ./autogen.sh && ./configure && make
 sudo make install
 ```


### PR DESCRIPTION
1. Steps about "build and install the latest mbedTLS" have a mistake. With these steps, the output file is *.a, static library, instead shared library.
2. No need to install libmbedtls and libsodium from repository, because they're built from latest source.
3. dh-autoreconf is needed when building deb on Debian/Ubuntu.  See #1174
