### PR TITLE
fixed missing apt pkg: automake

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ section below.
 
 ``` bash
 cd shadowsocks-libev
-sudo apt-get install --no-install-recommends gettext build-essential autoconf libtool \
+sudo apt-get install --no-install-recommends gettext build-essential autoconf automake libtool \
     gawk debhelper dh-systemd init-system-helpers pkg-config asciidoc xmlto apg libpcre3-dev \
     libev-dev libudns-dev dh-autoreconf
 ./autogen.sh && dpkg-buildpackage -b -us -uc -i


### PR DESCRIPTION
With the `--no-install-recommends` option, `apt` command will not install `automake` package automatically as recommended package of `autoconf`. So it should be installed clearly.