### PR TITLE
Clarify port_password usage in docs

### DIFF
--- a/doc/ss-manager.asciidoc
+++ b/doc/ss-manager.asciidoc
@@ -67,6 +67,9 @@ Set the socket timeout in seconds. The default value is 60.
 
 -c <config_file>::
 Use a configuration file.
++
+You may use "port_password" field inside this configuration file to bring up
+multiple ss-server instances together.
 
 -i <interface>::
 Send traffic through specific network interface.

--- a/doc/ss-server.asciidoc
+++ b/doc/ss-server.asciidoc
@@ -157,6 +157,7 @@ INCOMPATIBILITY
 ---------------
 The config file of `shadowsocks-libev`(8) is slightly different from original
 shadowsocks.
+
 In order to listen to both IPv4/IPv6 address, use the following grammar in
 your config json file:
 ....
@@ -165,6 +166,10 @@ your config json file:
 ...
 }
 ....
+
+`ss-server`(1) also does not understand "port_password" field in config file.
+If you want to start up multiple server instances with a single config file,
+please try ss-manager tool. See `ss-manager`(8) for details.
 
 SEE ALSO
 --------


### PR DESCRIPTION
Some more update in ss-manager and ss-server docs. Hope that my understanding is correct.