### PR TITLE
Output error log when repeat IV/salt detected

### DIFF
--- a/src/aead.c
+++ b/src/aead.c
@@ -635,6 +635,7 @@ aead_decrypt(buffer_t *ciphertext, cipher_ctx_t *cipher_ctx, size_t capacity)
         aead_cipher_ctx_set_key(cipher_ctx, 0);
 
         if (cache_key_exist(nonce_cache, (char *)cipher_ctx->salt, salt_len)) {
+            LOGE("crypto: AEAD: repeat salt detected");
             bfree(ciphertext);
             return CRYPTO_ERROR;
         } else {

--- a/src/stream.c
+++ b/src/stream.c
@@ -507,6 +507,7 @@ stream_decrypt(buffer_t *ciphertext, cipher_ctx_t *cipher_ctx, size_t capacity)
 
         if (cipher->method >= RC4_MD5) {
             if (cache_key_exist(nonce_cache, (char *)nonce, nonce_len)) {
+                LOGE("crypto: stream: repeat IV detected");
                 bfree(ciphertext);
                 return -1;
             } else {


### PR DESCRIPTION
This is useful when checking connection issues, and can be used to
check broken random number generator and replay attacks.

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>