### PR TITLE
Add tcp-fast-open support for ss-redir

### DIFF
--- a/src/redir.h
+++ b/src/redir.h
@@ -61,6 +61,7 @@ typedef struct server {
     size_t hostname_len;
 
     struct sockaddr_storage destaddr;
+    ev_timer delayed_connect_watcher;
 } server_t;
 
 typedef struct remote_ctx {
@@ -77,6 +78,7 @@ typedef struct remote {
     struct remote_ctx *send_ctx;
     struct server *server;
     uint32_t counter;
+    struct sockaddr *addr;
 } remote_t;
 
 #endif // _REDIR_H

--- a/src/utils.c
+++ b/src/utils.c
@@ -345,7 +345,7 @@ usage()
 #endif
     printf(
         "       [--reuse-port]             Enable port reuse.\n");
-#if defined(MODULE_REMOTE) || defined(MODULE_LOCAL)
+#if defined(MODULE_REMOTE) || defined(MODULE_LOCAL) || defined(MODULE_REDIR)
     printf(
         "       [--fast-open]              Enable TCP fast open.\n");
     printf(


### PR DESCRIPTION
给 ss-redir 增加了 TFO 支持。

当 ss-redir 接受客户端的连接后，会等待 5ms 让客户端发送数据（例如 HTTP 请求），让这个数据能带在 SYN 中发给 ss-server。这样就能做到在 1-RTT 中完成整个 HTTP 请求与响应（也包括将来的 TLS1.3）。