### PR TITLE
Rewrite genrpm.sh to build RPM from current Git workspace

### DIFF
--- a/rpm/SPECS/shadowsocks-libev.spec.in
+++ b/rpm/SPECS/shadowsocks-libev.spec.in
@@ -1,7 +1,3 @@
-%bcond_with completion
-%bcond_with autogen
-
-
 Name:		shadowsocks-libev
 Version:	VERSION
 Release:	1%{?dist}
@@ -55,9 +51,7 @@ shadowsocks-libev is a lightweight secured scoks5 proxy for embedded devices and
 
 
 %build
-%if %{with autogen}
 ./autogen.sh
-%endif
 
 %if 0%{?use_system_lib}
 %configure --enable-shared --enable-system-shared-lib
@@ -82,17 +76,15 @@ install -m 644 %{_builddir}/%{buildsubdir}/debian/shadowsocks-libev-*.service %{
 %endif
 install -m 644 %{_builddir}/%{buildsubdir}/debian/config.json %{buildroot}%{_sysconfdir}/shadowsocks-libev/config.json
 
-%if %{with completion}
 mkdir -p %{buildroot}%{_datadir}/bash-completion/completions/
 install -m 644 %{_builddir}/%{buildsubdir}/completions/bash/* %{buildroot}%{_datadir}/bash-completion/completions/
-%endif
 
 %pre
 %if 0%{?use_systemd} && 0%{?suse_version}
 %service_add_pre shadowsocks-libev.service
 %endif
 
-%post
+%post -p /sbin/ldconfig
 %if ! 0%{?use_systemd}
 /sbin/chkconfig --add shadowsocks-libev > /dev/null 2>&1 || :
 %else
@@ -117,7 +109,7 @@ fi
 %endif
 %endif
 
-%postun
+%postun -p /sbin/ldconfig
 %if 0%{?use_systemd}
 %if 0%{?suse_version}
 %service_del_postun shadowsocks-libev.service
@@ -137,9 +129,7 @@ fi
 %{_bindir}/*
 %{_libdir}/*.so.*
 %config(noreplace) %{_sysconfdir}/shadowsocks-libev/config.json
-%if %{with completion}
 %{_datadir}/bash-completion/completions/*
-%endif
 %doc %{_mandir}/*
 %if ! 0%{?use_systemd}
 %{_initddir}/shadowsocks-libev

--- a/rpm/genrpm.sh
+++ b/rpm/genrpm.sh
@@ -1,118 +1,86 @@
 #!/usr/bin/env bash
 set -e
 
-g_script_path=$(dirname $(readlink -e $0))
-g_toplevel_path=$(pushd $g_script_path > /dev/null 2>&1; \
-                  git rev-parse --show-toplevel; \
-                  popd > /dev/null 2>&1)
-
-g_version=$(git tag -l v* | sort --version-sort | tail -1)
-g_version=${g_version#"v"}
-g_format="tar.gz"
-g_name="shadowsocks-libev"
-
-g_rpmbuild_topdir="${g_toplevel_path}/rpm"
-g_rpmbuild_conditions=
+SELF=$(readlink -f -- "$0")
+HERE=$(dirname -- "$SELF")
 
 show_help()
 {
-    echo -e "`basename $0`  [option] [argument]"
+    echo -e "`basename $0` [OPTION...]"
     echo
     echo -e "Options:"
     echo -e "  -h    show this help."
-    echo -e "  -v    with argument version (${g_version} by default)."
-    echo -e "  -f    with argument format (tar.gz by default) used by git archive."
-    echo
-    echo -e "Examples:"
-    echo -e "  to build base on version \`2.4.1' with format \`tar.xz', run:"
-    echo -e "    `basename $0` -f tar.xz -v 2.4.1"
+    echo -e "  -s    use system shared libraries"
 }
 
-version_greater_equal()
-{
-    [ "$1" = $(printf "$1\n$2\n" | sort --version-sort | tail -1) ]
-}
+OPT_USE_SYSTEM_LIB=0
 
-verify_options()
-{
-    local completion_min_verion="2.6.0"
-    local archive_format_supported_max_version="2.6.2"
-
-    version_greater_equal ${g_version} ${completion_min_verion} \
-        && g_rpmbuild_conditions="${g_rpmbuild_conditions} --with completion" || :
-
-    if ! version_greater_equal ${archive_format_supported_max_version} ${g_version}; then
-        g_rpmbuild_conditions="${g_rpmbuild_conditions} --with autogen"
-
-        if [ "${g_format}" != "tar" ]; then
-            echo -e "version(${g_version}) greater than ${archive_format_supported_max_version} can only use archive format \`tar'."
-            echo -e "change format from \`${g_format}' to \`tar'"
-            g_format="tar"
-        fi
-    fi
-}
-
-generate_tarball()
-{
-    local tarball_name="${g_name}-${g_version}"
-    local tarball_dir="${g_rpmbuild_topdir}/SOURCES"
-
-    pushd ${g_toplevel_path}
-
-    git archive "v${g_version}" \
-        --format="${g_format}" \
-        --prefix="${tarball_name}/" \
-        -o "${tarball_dir}/${tarball_name}.${g_format}"
-
-    git ls-tree -dr "v${g_version}" | grep commit \
-        | while read eat_mod eat_type mod_sha mod_path; do \
-        [ "${mod_path}" = "" ] && continue || :; \
-        (pushd ${mod_path} \
-                && git archive ${mod_sha} \
-                       --prefix="${tarball_name}/${mod_path}/" \
-                       -o "${tarball_dir}/sub_mod.tar" \
-                && tar --concatenate "${tarball_dir}/sub_mod.tar" \
-                       --file="${tarball_dir}/${tarball_name}.tar" \
-                && rm "${tarball_dir}/sub_mod.tar" \
-                && popd) \
-            done
-
-    popd
-}
-
-while getopts "hv:f:" opt
+while getopts "hs" opt
 do
     case ${opt} in
         h)
             show_help
             exit 0
             ;;
-        v)
-            if [ "${OPTARG}" = v* ]; then
-                g_version=${OPTARG#"v"}
-            else
-                g_version=${OPTARG}
-            fi
-            ;;
-        f)
-            g_format=${OPTARG}
-            ;;
+
+		s)
+            OPT_USE_SYSTEM_LIB=1
+			;;
         *)
+			show_help
             exit 1
             ;;
     esac
 done
 
-verify_options
+# determine version and release number
+GIT_DESCRIBE=$(git describe --tags --match 'v*' --long --dirty)
+# GIT_DESCRIBE is like v3.0.3-11-g1e3f35c-dirty
 
-generate_tarball
+if [[ ! "$GIT_DESCRIBE" =~ ^v([^-]+)-([0-9]+)-g([0-9a-f]+)(-dirty)?$ ]]; then
+    >&2 echo 'ERROR - unrecognized `git describe` output: '"$GIT_DESCRIBE"
+    exit 1
+fi
 
-spec_path="${g_rpmbuild_topdir}/SPECS/shadowsocks-libev.spec"
-sed -e "s/^\(Version:	\).*$/\1${g_version}/" \
-    -e "s/^\(Source0:	\).*$/\1${g_name}-${g_version}.${g_format}/" \
-    "${spec_path}".in > "${spec_path}"
+TARGET_VERSION=${BASH_REMATCH[1]}
+TARGET_COMMITS=${BASH_REMATCH[2]}
+TARGET_SHA1=${BASH_REMATCH[3]}
+TARGET_DIRTY=${BASH_REMATCH[4]}
 
-rpmbuild -bb ${spec_path} \
-         --define "%_topdir ${g_rpmbuild_topdir}" \
-         --define "%use_system_lib 1" \
-         ${g_rpmbuild_conditions}
+TARGET_RELEASE=1
+if [ "$TARGET_COMMITS" -gt 0 ]; then
+    TARGET_RELEASE+=".$TARGET_COMMITS.git$TARGET_SHA1"
+fi
+if [ -n "$TARGET_DIRTY" ]; then
+    TARGET_RELEASE+=.dirty
+fi
+
+TARGET_VERREL=$TARGET_VERSION-$TARGET_RELEASE
+>&2 echo "INFO - RPM version-release is $TARGET_VERREL."
+
+
+# archive tarball from Git workspace
+TARGET_TARBALL_NAME=shadowsocks-libev-$TARGET_VERSION
+TARGET_TARBALL_DIR=$HERE/SOURCES
+mkdir -p -- "$TARGET_TARBALL_DIR"
+#git archive HEAD --format=tar --prefix="$TARGET_TARBALL_NAME/" \
+#    -o "$TARGET_TARBALL_DIR/$TARGET_TARBALL_NAME.tar"   
+pushd "$HERE"/..
+pwd
+tar --exclude './rpm' --exclude '.[^/]*'  --transform "s,^\.,$TARGET_TARBALL_NAME," \
+    -cvf "$TARGET_TARBALL_DIR/$TARGET_TARBALL_NAME.tar" .
+popd
+
+# generate spec file
+TARGET_SPEC_DIR=$HERE/SPECS
+mkdir -p -- "$TARGET_SPEC_DIR"
+TARGET_SPEC_PATH=$TARGET_SPEC_DIR/shadowsocks-libev.spec
+sed -e "s/^\(Version:\).*$/\1       ${TARGET_VERSION}/" \
+    -e "s/^\(Release:\).*$/\1       ${TARGET_RELEASE}%{?dist}/" \
+    -e "s/^\(Source0:\).*$/\1       ${TARGET_TARBALL_NAME}.tar/" \
+    "${TARGET_SPEC_PATH}".in > "${TARGET_SPEC_PATH}"
+
+# build rpms
+rpmbuild -ba "$TARGET_SPEC_PATH" \
+         --define "%_topdir $HERE" \
+         --define "%use_system_lib $OPT_USE_SYSTEM_LIB"


### PR DESCRIPTION
Here are the problems existing in the old RPM packaging scripts:

1. The old `genrpm.sh` is designed to build RPMs for all versions of
shadowsocks-libev with an option '-v'.
This increases the complexity because we need to keep it compatible
with old versions.
2. I have to modify the script manually in order to build RPMs from
non-release commit or dirty workspace.

The new script will only build RPMs and SRPMs from current workspace,
not commit.
The version-release number will be determined automatically from the
`git describe` command.