### PR TITLE
fix rpm SPEC file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,11 @@ shadowsocks-libev.pc
 debian/libshadowsocks-libev*.symbols
 libsodium/src/libsodium/include/sodium/version.h
 rpm/SPECS/shadowsocks-libev.spec
+rpm/SRPMS
+rpm/RPMS/
+rpm/SOURCES/
+!rpm/SOURCES/etc/init.d/shadowsocks-libev
+rpm/BUILD
 
 # Ignore per-project vim config
 .vimrc

--- a/m4/sodium.m4
+++ b/m4/sodium.m4
@@ -30,11 +30,11 @@ AC_DEFUN([ss_SODIUM],
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
     #include <sodium.h>
     ], [
-    #if SODIUM_LIBRARY_VERSION_MAJOR < 8
+    #if SODIUM_LIBRARY_VERSION_MAJOR < 7 || SODIUM_LIBRARY_VERSION_MAJOR ==7 && SODIUM_LIBRARY_VERSION_MINOR < 6
     # error
     #endif
     ])],
     [AC_MSG_RESULT([checking for version of libsodium... yes])],
-    [AC_MSG_ERROR([Wrong libsodium: version >= 1.0.8 required])])
+    [AC_MSG_ERROR([Wrong libsodium: version >= 1.0.4 required])])
 
 ])

--- a/rpm/SPECS/shadowsocks-libev.spec.in
+++ b/rpm/SPECS/shadowsocks-libev.spec.in
@@ -10,8 +10,10 @@ Source0:	%{url}/archive/v%{version}.tar.gz
 
 AutoReq:        no
 Conflicts:	    python-shadowsocks python3-shadowsocks
-BuildRequires:	make gcc pcre-devel asciidoc xmlto
-Requires:       pcre
+BuildRequires:	make gcc pcre-devel asciidoc xmlto automake libtool mbedtls-devel libsodium-devel >= 1.0.4 libev-devel udns-devel
+Requires:       pcre mbedtls libsodium >= 1.0.4
+Requires:       libev udns
+
 
 %if 0%{?suse_version}
 Requires:       libopenssl1_0_0
@@ -34,11 +36,6 @@ BuildRequires:   systemd-rpm-macros
 %else
 BuildRequires:   systemd
 %endif
-%endif
-
-%if 0%{?use_system_lib}
-BuildRequires:  libev-devel libsodium-devel >= 1.0.4 udns-devel
-Requires:       libev libsodium >= 1.0.4 udns
 %endif
 
 
@@ -84,7 +81,8 @@ install -m 644 %{_builddir}/%{buildsubdir}/completions/bash/* %{buildroot}%{_dat
 %service_add_pre shadowsocks-libev.service
 %endif
 
-%post -p /sbin/ldconfig
+%post
+/sbin/ldconfig
 %if ! 0%{?use_systemd}
 /sbin/chkconfig --add shadowsocks-libev > /dev/null 2>&1 || :
 %else
@@ -109,7 +107,8 @@ fi
 %endif
 %endif
 
-%postun -p /sbin/ldconfig
+%postun
+/sbin/ldconfig
 %if 0%{?use_systemd}
 %if 0%{?suse_version}
 %service_del_postun shadowsocks-libev.service

--- a/rpm/genrpm.sh
+++ b/rpm/genrpm.sh
@@ -66,7 +66,7 @@ mkdir -p -- "$TARGET_TARBALL_DIR"
 #git archive HEAD --format=tar --prefix="$TARGET_TARBALL_NAME/" \
 #    -o "$TARGET_TARBALL_DIR/$TARGET_TARBALL_NAME.tar"   
 pushd "$HERE"/..
-pwd
+make clean
 tar --exclude './rpm' --exclude '.[^/]*'  --transform "s,^\.,$TARGET_TARBALL_NAME," \
     -cvf "$TARGET_TARBALL_DIR/$TARGET_TARBALL_NAME.tar" .
 popd


### PR DESCRIPTION
1. add missing build and runtime dependencies
2. change minimal version requirement for libsodium to 1.0.4, which
should work fine with ss-libev and EPEL7 users will not have to compile a
later version.
3. add more entries to .gitignore