### PR TITLE
mptcp: make shadowsocks kernel independant

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -1112,9 +1112,21 @@ create_remote(listen_ctx_t *listener,
     setsockopt(remotefd, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof(opt));
 #endif
 
-    if (listener->mptcp == 1) {
-        int err = setsockopt(remotefd, SOL_TCP, MPTCP_ENABLED, &opt, sizeof(opt));
+    if (listener->mptcp > 1) {
+        int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
         if (err == -1) {
+            ERROR("failed to enable multipath TCP");
+        }
+    } else if (listener->mptcp == 1) {
+        int i = 0;
+        while((listener->mptcp = mptcp_enabled_values[i]) > 0) {
+            int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
+            if (err != -1) {
+                break;
+            }
+            i++;
+        }
+        if (listener->mptcp == 0) {
             ERROR("failed to enable multipath TCP");
         }
     }

--- a/src/netutils.h
+++ b/src/netutils.h
@@ -46,13 +46,11 @@
 #endif
 #endif
 
-/* Backward compatibility for MPTCP_ENABLED between kernel 3 & 4 */
+/* MPTCP_ENABLED setsockopt values for kernel 4 & 3, best behaviour to be independant of kernel version is to test from newest to the latest values */
 #ifndef MPTCP_ENABLED
-#ifdef TCP_CC_INFO
-#define MPTCP_ENABLED 42
+static const char mptcp_enabled_values[] = { 42, 26, 0 };
 #else
-#define MPTCP_ENABLED 26
-#endif
+static const char mptcp_enabled_values[] = { MPTCP_ENABLED, 0 };
 #endif
 
 #ifndef UPDATE_INTERVAL

--- a/src/redir.c
+++ b/src/redir.c
@@ -784,9 +784,21 @@ accept_cb(EV_P_ ev_io *w, int revents)
     setnonblocking(remotefd);
 
     // Enable MPTCP
-    if (listener->mptcp == 1) {
-        int err = setsockopt(remotefd, SOL_TCP, MPTCP_ENABLED, &opt, sizeof(opt));
+    if (listener->mptcp > 1) {
+        int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
         if (err == -1) {
+            ERROR("failed to enable multipath TCP");
+        }
+    } else if (listener->mptcp == 1) {
+        int i = 0;
+        while((listener->mptcp = mptcp_enabled_values[i]) > 0) {
+            int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
+            if (err != -1) {
+                break;
+            }
+            i++;
+        }
+        if (listener->mptcp == 0) {
             ERROR("failed to enable multipath TCP");
         }
     }

--- a/src/server.c
+++ b/src/server.c
@@ -388,8 +388,15 @@ create_and_bind(const char *host, const char *port, int mptcp)
         }
 
         if (mptcp == 1) {
-            int err = setsockopt(listen_sock, SOL_TCP, MPTCP_ENABLED, &opt, sizeof(opt));
-            if (err == -1) {
+            int i = 0;
+            while((mptcp = mptcp_enabled_values[i]) > 0) {
+                int err = setsockopt(listen_sock, IPPROTO_TCP, mptcp, &opt, sizeof(opt));
+                if (err != -1) {
+                    break;
+                }
+                i++;
+            }
+            if (mptcp == 0) {
                 ERROR("failed to enable multipath TCP");
             }
         }

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -659,9 +659,21 @@ accept_cb(EV_P_ ev_io *w, int revents)
     setsockopt(remotefd, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof(opt));
 #endif
 
-    if (listener->mptcp == 1) {
-        int err = setsockopt(remotefd, SOL_TCP, MPTCP_ENABLED, &opt, sizeof(opt));
+    if (listener->mptcp > 1) {
+        int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
         if (err == -1) {
+            ERROR("failed to enable multipath TCP");
+        }
+    } else if (listener->mptcp == 1) {
+       int i = 0;
+       while((listener->mptcp = mptcp_enabled_values[i]) > 0) {
+            int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
+            if (err != -1) {
+                break;
+            }
+            i++;
+        }
+        if (listener->mptcp == 0) {
             ERROR("failed to enable multipath TCP");
         }
     }


### PR DESCRIPTION
According to mptcp developers the best way to make mptcp application kernel indepedant is to test MPTCP_ENABLED values from the newest to the oldest.

- Replace defined MPTCP_ENABLED value by an array of all known values ended by a 0.
- If MPTCP_ENABLED value is defined at compile time fill the array with only this value.
- Reuse mptcp var to store the real value of the discovered kernel value.
- Mptcp var value of 1 mean to discover the value from the kernel whereas >1 mean that the value is already known/discovered and can be used as it. if mptcp var is 0 then mptcp is not supported by the kernel.

Further improvements : 
- listener->mptcp from ctx should be a pointer to the main common mptcp var to be able to report the discovered kernel value to future remote connections.