### PR TITLE
Allow the use of pwgen to generate passwords

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Replaces: shadowsocks (<< 1.5.3-2)
 Breaks: shadowsocks (<< 1.5.3-2)
 Architecture: any
 Depends:
- apg,
+ apg | pwgen,
  libcap2-bin [linux-any],
  lsb-base (>= 3.0-6),
  ${misc:Depends},

--- a/debian/shadowsocks-libev.postinst
+++ b/debian/shadowsocks-libev.postinst
@@ -26,7 +26,12 @@ case "$1" in
 			cap_net_bind_service+ep /usr/bin/ss-server \
 			cap_net_bind_service+ep /usr/bin/ss-tunnel
 		if [ ! -f /etc/shadowsocks-libev/config.json ]; then
-			passwd=$(apg -n 1 -M ncl)
+			pathfind apg
+			if [ $? -eq 0 ]; then
+				passwd=$(apg -n 1 -M ncl)
+			else
+				passwd=$(pwgen 12 1)
+			fi
 			mkdir -p /etc/shadowsocks-libev
 			sed "s/barfoo!/$passwd/" /usr/share/shadowsocks-libev/config.json \
 				> /etc/shadowsocks-libev/config.json


### PR DESCRIPTION
I prefer to use `pwgen` and it is already installed in my system. Allow using `pwgen` as the password generator so I'm not forced to install `apg`.