### PR TITLE
Turn off errexit option when detecting the apg command

### DIFF
--- a/debian/shadowsocks-libev.postinst
+++ b/debian/shadowsocks-libev.postinst
@@ -26,12 +26,14 @@ case "$1" in
 			cap_net_bind_service+ep /usr/bin/ss-server \
 			cap_net_bind_service+ep /usr/bin/ss-tunnel
 		if [ ! -f /etc/shadowsocks-libev/config.json ]; then
+			set +e
 			pathfind apg
 			if [ $? -eq 0 ]; then
 				passwd=$(apg -n 1 -M ncl)
 			else
 				passwd=$(pwgen 12 1)
 			fi
+			set -e
 			mkdir -p /etc/shadowsocks-libev
 			sed "s/barfoo!/$passwd/" /usr/share/shadowsocks-libev/config.json \
 				> /etc/shadowsocks-libev/config.json


### PR DESCRIPTION
The commit https://github.com/shadowsocks/shadowsocks-libev/commit/f32ac38c2f7aab09ec25131209954957518de42a allows to use `pwgen` to generate the initial password at the first installation.
However it won't work when `apg` isn't installed because:

* the `postinst` script has the errexit option set (`set -e`)
* at the first installation of ss-libev, `apg` or `pwgen` needs to be called to generate the initial password in config.json
* when `apg` isn't installed, `pathfind apg` would return 1
* and the `postinst` script will immediately exit due to `set -e`

This commit temporarily turn off the errexit option when running `pathfind`.

Below is my logs of tracking this issue down (by manually installing a deb I built):

```
root@trag:~# dpkg -i shadowsocks-libev_3.0.3-1_amd64.deb
Selecting previously unselected package shadowsocks-libev.
(Reading database ... 31863 files and directories currently installed.)
Preparing to unpack shadowsocks-libev_3.0.3-1_amd64.deb ...
Unpacking shadowsocks-libev (3.0.3-1) ...
Setting up shadowsocks-libev (3.0.3-1) ...
dpkg: error processing package shadowsocks-libev (--install):
 subprocess installed post-installation script returned error exit status 1
Processing triggers for systemd (229-4ubuntu16) ...
Processing triggers for man-db (2.7.5-1) ...
Errors were encountered while processing:
 shadowsocks-libev

root@trag:~# sh -x /var/lib/dpkg/info/shadowsocks-libev.postinst configure 3.0.3-1
+ set -e
+ pathfind setcap
+ OLDIFS=

+ IFS=:
+ [ -x /usr/local/sbin/setcap ]
+ [ -x /usr/local/bin/setcap ]
+ [ -x /usr/sbin/setcap ]
+ [ -x /usr/bin/setcap ]
+ [ -x /sbin/setcap ]
+ IFS=

+ return 0
+ setcap cap_net_bind_service+ep /usr/bin/ss-local cap_net_bind_service,cap_net_admin+ep /usr/bin/ss-redir cap_net_bind_service+ep /usr/bin/ss-server cap_net_bind_service+ep /usr/bin/ss-tunnel
+ [ ! -f /etc/shadowsocks-libev/config.json ]
+ pathfind apg
+ OLDIFS=

+ IFS=:
+ [ -x /usr/local/sbin/apg ]
+ [ -x /usr/local/bin/apg ]
+ [ -x /usr/sbin/apg ]
+ [ -x /usr/bin/apg ]
+ [ -x /sbin/apg ]
+ [ -x /bin/apg ]
+ [ -x /usr/games/apg ]
+ [ -x /usr/local/games/apg ]
+ IFS=

+ return 1
```
