### PR TITLE
Update gfwlist.acl

### DIFF
--- a/acl/gfwlist.acl
+++ b/acl/gfwlist.acl
@@ -398,7 +398,6 @@
 (^|\.)zynamics\.com$
 (^|\.)kat\.cr$
 (^|\.)naughtyamerica\.com$
-(^|\.)v2ex\.com$
 (^|\.)0to255\.com$
 (^|\.)100ke\.org$
 (^|\.)1000giri\.net$


### PR DESCRIPTION
V2EX has already registered an ICP license and can be visited normally in CHINA