### PR TITLE
Add method, fast_open, mode, plugin options to ss-manager

### DIFF
--- a/src/manager.h
+++ b/src/manager.h
@@ -67,6 +67,11 @@ struct manager_ctx {
 struct server {
     char port[8];
     char password[128];
+    char fast_open[8];
+    char *mode;
+    char *method;
+    char *plugin;
+    char *plugin_opts;
     uint64_t traffic;
 };
 


### PR DESCRIPTION
Hello,
I tried to add options ```method, fast_open, mode, plugin, plugin-opts``` to ss-manager.
So that we can ```add: {"method": "aes-256-gcm", "server_port": "12345", "fast_open": true, "plugin": "obfs-server", "plugin_opts": "obfs=http", "mode": "udp_only"}``` now.

Parameter ```server_port``` and ```password``` are still necessary, and others are optional.