### PR TITLE
Update the ciphersuite `method` in debian/config.json.

### DIFF
--- a/debian/config.json
+++ b/debian/config.json
@@ -4,5 +4,5 @@
     "local_port":1080,
     "password":"barfoo!",
     "timeout":60,
-    "method":"rc4-md5"
+    "method":"chacha20-ietf-poly1305"
 }


### PR DESCRIPTION
6d9732a changes the "method" parameter in the debian/config.json
from "rc4-md5" to "chacha20-ietf-poly1305". rc4-md5 is unsafe and
there is support for a better AEAD ciphersuite.