### PR TITLE
cmake option for skip static libraries check or not.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ endif ()
 
 message(STATUS "Running cmake version ${CMAKE_VERSION}")
 
+option(WITH_STATIC "build with static libraries." ON)
+
 # Will set GIT_EXECUTABLE and GIT_FOUND
 # find_package(Git)
 
@@ -83,8 +85,10 @@ set(LIBCORK_SOURCE
         libcork/src/libcork/pthreads/thread.c
         )
 
+if (WITH_STATIC)
 add_library(cork STATIC ${LIBCORK_SOURCE})
 target_compile_definitions(cork PUBLIC -DCORK_API=CORK_LOCAL)
+endif ()
 
 add_library(cork-shared SHARED ${LIBCORK_SOURCE})
 target_compile_definitions(cork-shared PUBLIC -DCORK_API=CORK_EXPORT)
@@ -112,7 +116,9 @@ set(LIBIPSET_SOURCE
         libipset/src/libipset/set/storage.c
         )
 
+if (WITH_STATIC)
 add_library(ipset STATIC ${LIBIPSET_SOURCE})
+endif ()
 
 add_library(ipset-shared SHARED ${LIBIPSET_SOURCE})
 set_target_properties(ipset-shared PROPERTIES OUTPUT_NAME ipset)
@@ -122,8 +128,10 @@ set(LIBBLOOM_SOURCE
         libbloom/murmur2/MurmurHash2.c
         )
 
+if (WITH_STATIC)
 add_library(bloom STATIC ${LIBBLOOM_SOURCE})
 target_link_libraries(ipset cork bloom)
+endif ()
 
 add_library(bloom-shared SHARED ${LIBBLOOM_SOURCE})
 target_link_libraries(ipset-shared cork-shared bloom-shared)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,12 +83,14 @@ set(SS_REDIR_SOURCE
         )
 
 
+if (WITH_STATIC)
 find_library(LIBSODIUM libsodium.a)
 find_library(LIBMBEDTLS libmbedtls.a)
 find_library(LIBMBEDCRYPTO libmbedcrypto.a)
 find_library(LIBEV libev.a)
 find_library(LIBUDNS libudns.a)
 find_library(LIBPCRE libpcre.a)
+endif ()
 
 find_library(LIBSODIUM_SHARED sodium)
 find_library(LIBMBEDTLS_SHARED mbedtls)
@@ -98,6 +100,7 @@ find_library(LIBUDNS_SHARED udns)
 find_library(LIBPCRE_SHARED pcre)
 
 # Dependencies we need for static and shared
+if (WITH_STATIC)
 list(APPEND DEPS
         m
         bloom
@@ -108,6 +111,8 @@ list(APPEND DEPS
         ${LIBMBEDTLS}
         ${LIBMBEDCRYPTO}
         )
+endif ()
+
 list(APPEND DEPS_SHARED
         m
         bloom-shared
@@ -121,6 +126,7 @@ list(APPEND DEPS_SHARED
 
 find_package (Threads)
 
+if (WITH_STATIC)
 # ------------------------------------------------------------------
 # Static
 # By default we use normal name for static, all shared targets will add a `-shared' suffix
@@ -149,6 +155,7 @@ target_link_libraries(ss-manager m bloom cork ${LIBEV} ${LIBUDNS})
 target_link_libraries(ss-local cork ipset ${DEPS})
 target_link_libraries(ss-redir cork ipset ${DEPS})
 target_link_libraries(shadowsocks-libev cork ipset ${DEPS})
+endif ()
 
 # ------------------------------------------------------------------
 # Shared
@@ -200,9 +207,15 @@ target_link_libraries(shadowsocks-libev-shared cork-shared ipset-shared ${DEPS_S
 # Recommend to install shared by default
 install(DIRECTORY ${RUNTIME_SHARED_OUTPUT_DIRECTORY}/
         DESTINATION bin)
-install(TARGETS shadowsocks-libev shadowsocks-libev-shared
-        LIBRARY DESTINATION lib
+
+if (WITH_STATIC)
+    install(TARGETS shadowsocks-libev
         ARCHIVE DESTINATION lib)
+endif ()
+
+install(TARGETS shadowsocks-libev-shared
+        LIBRARY DESTINATION lib)
+
 install(FILES shadowsocks.h DESTINATION include)
 
 


### PR DESCRIPTION
Add a option in CMakeLists.txt for switch build with static libraries or not.
When you don't have static libraries, run with "cmake -DWITH_STATIC=OFF".
This is useful when you trying use QtCreator to browse the project.