### PR TITLE
Fix decryption failed issue by nonce overwrite

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -493,7 +493,7 @@ stream_decrypt(buffer_t *ciphertext, cipher_ctx_t *cipher_ctx, size_t capacity)
                               ciphertext->len);
 
         if (left_len > 0) {
-            memcpy(cipher_ctx->chunk->data, ciphertext->data, left_len);
+            memcpy(cipher_ctx->chunk->data + cipher_ctx->chunk->len, ciphertext->data, left_len);
             memmove(ciphertext->data, ciphertext->data + left_len,
                     ciphertext->len - left_len);
             cipher_ctx->chunk->len += left_len;


### PR DESCRIPTION
If the first packet is less than nonce length, then the chunk nonce data will be overwrote by next packet and result in decrypt failed