### PR TITLE
Fix losing data issue of SALSA20 cipher

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -505,7 +505,7 @@ stream_decrypt(buffer_t *ciphertext, cipher_ctx_t *cipher_ctx, size_t capacity)
 
         uint8_t *nonce   = cipher_ctx->nonce;
         size_t nonce_len = cipher->nonce_len;
-        plaintext->len -= nonce_len;
+        plaintext->len -= left_len;
 
         memcpy(nonce, cipher_ctx->chunk->data, nonce_len);
         cipher_ctx_set_nonce(cipher_ctx, nonce, nonce_len, 0);


### PR DESCRIPTION
If nonce received in more than one packet under some network condition, the salsa20 cipher decryption will lose cipher->nonce_len - left_len bytes of data.