### PR TITLE
ss-redir: Add option to disable SNI feature

### DIFF
--- a/src/jconf.c
+++ b/src/jconf.c
@@ -257,6 +257,10 @@ read_jconf(const char *file)
                 check_json_value_type(value, json_boolean,
                         "invalid config file: option 'reuse_port' must be a boolean");
                 conf.reuse_port = value->u.boolean;
+            } else if (strcmp(name, "disable_sni") == 0) {
+                check_json_value_type(value, json_boolean,
+                        "invalid config file: option 'disable_sni' must be a boolean");
+                conf.disable_sni = value->u.boolean;
             } else if (strcmp(name, "auth") == 0) {
                 FATAL("One time auth has been deprecated. Try AEAD ciphers instead.");
             } else if (strcmp(name, "nofile") == 0) {

--- a/src/jconf.h
+++ b/src/jconf.h
@@ -76,6 +76,7 @@ typedef struct {
     char *plugin_opts;
     int fast_open;
     int reuse_port;
+    int disable_sni;
     int nofile;
     char *nameserver;
     int dscp_num;

--- a/src/redir.c
+++ b/src/redir.c
@@ -89,6 +89,7 @@ static void close_and_free_server(EV_P_ server_t *server);
 int verbose        = 0;
 int reuse_port     = 0;
 int keep_resolving = 1;
+int disable_sni    = 0;
 
 static crypto_t *crypto;
 
@@ -239,23 +240,24 @@ server_recv_cb(EV_P_ ev_io *w, int revents)
     }
 
     if (!remote->send_ctx->connected) {
-        // SNI
-        int ret       = 0;
-        uint16_t port = 0;
-
-        if (AF_INET6 == server->destaddr.ss_family) { // IPv6
-            port = ntohs(((struct sockaddr_in6 *)&(server->destaddr))->sin6_port);
-        } else {                             // IPv4
-            port = ntohs(((struct sockaddr_in *)&(server->destaddr))->sin_port);
-        }
-        if (port == http_protocol->default_port)
-            ret = http_protocol->parse_packet(remote->buf->data,
-                                              remote->buf->len, &server->hostname);
-        else if (port == tls_protocol->default_port)
-            ret = tls_protocol->parse_packet(remote->buf->data,
-                                             remote->buf->len, &server->hostname);
-        if (ret > 0) {
-            server->hostname_len = ret;
+        if (!disable_sni) {
+            // SNI
+            int ret       = 0;
+            uint16_t port = 0;
+            if (AF_INET6 == server->destaddr.ss_family) { // IPv6
+                port = ntohs(((struct sockaddr_in6 *)&(server->destaddr))->sin6_port);
+            } else {                             // IPv4
+                port = ntohs(((struct sockaddr_in *)&(server->destaddr))->sin_port);
+            }
+            if (port == http_protocol->default_port)
+                ret = http_protocol->parse_packet(remote->buf->data,
+                                                  remote->buf->len, &server->hostname);
+            else if (port == tls_protocol->default_port)
+                ret = tls_protocol->parse_packet(remote->buf->data,
+                                                 remote->buf->len, &server->hostname);
+            if (ret > 0) {
+                server->hostname_len = ret;
+            }
         }
 
         ev_io_stop(EV_A_ & server_recv_ctx->io);
@@ -1064,6 +1066,9 @@ main(int argc, char **argv)
         }
         if (reuse_port == 0) {
             reuse_port = conf->reuse_port;
+        }
+        if (disable_sni == 0) {
+            disable_sni = conf->disable_sni;
         }
         if (fast_open == 0) {
             fast_open = conf->fast_open;


### PR DESCRIPTION
Add an option 'disable_sni' in the config file to allow clients running
ss-redir to disable the HTTP/SNI feature

As proposed here https://github.com/shadowsocks/shadowsocks-libev/issues/1503 , the option will disable the http/sni feature in ss-redir, keeping the default behaviour (sni enabled by default)

Don't know if a mention in the ascii doc, or if a command line argument are needed