### PR TITLE
Move <sys/socket.h> inclusion to fix build on DFlyBSD

### DIFF
--- a/src/netutils.c
+++ b/src/netutils.c
@@ -29,7 +29,6 @@
 #include "config.h"
 #endif
 
-#include <sys/socket.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <unistd.h>

--- a/src/netutils.h
+++ b/src/netutils.h
@@ -23,6 +23,8 @@
 #ifndef _NETUTILS_H
 #define _NETUTILS_H
 
+#include <sys/socket.h>
+
 #if defined(__linux__)
 #include <netdb.h>
 #else


### PR DESCRIPTION
The ``<sys/socket.h>`` header should be included in ``src/netutils.h``
before the usage of ``struct sockaddr_storage``, otherwise build failed
with errors such as:

```
In file included from udprelay.c:53:0:
netutils.h:68:22: error: 'struct sockaddr_storage' declared inside parameter list [-Werror]
                      int ipv6first);
                      ^
netutils.h:68:22: error: its scope is only this definition or declaration, which is probably not what you want [-Werror]
```

Tested on DragonFly BSD 4.9-development and Debian Linux testing.