### PR TITLE
Add ARGS env variable to alpine Dockerfile

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -15,6 +15,7 @@ ENV METHOD      aes-256-cfb
 ENV TIMEOUT     300
 ENV DNS_ADDR    8.8.8.8
 ENV DNS_ADDR_2  8.8.4.4
+ENV ARGS=
 
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps \
@@ -58,4 +59,5 @@ CMD ss-server -s $SERVER_ADDR \
               --fast-open \
               -d $DNS_ADDR \
               -d $DNS_ADDR_2 \
-              -u
+              -u \
+              $ARGS

--- a/docker/alpine/README.md
+++ b/docker/alpine/README.md
@@ -32,6 +32,7 @@ $ docker ps
 ```
 
 > :warning: Click [here][6] to generate a strong password to protect your server.
+> You can use `ARGS` environment variable to pass additional arguments
 
 ## Use docker-compose to manage (optional)
 


### PR DESCRIPTION
### Modification
alpine/Dockerfile: add a new `ARGS` environment variable to pass additional arguments.

### Use case
```shell
# start a ss-server that prefers IPv6
docker run -e PASSWORD=password -e ARGS='-6' shadowsocks-libev
```

### Commit
https://github.com/wacky6/shadowsocks-libev/commit/5059a0cdef19aa25f42df89f047e5d0bf7a95437