### PR TITLE
Fix #1533

### DIFF
--- a/rpm/SOURCES/0001-systemd-services.patch
+++ b/rpm/SOURCES/0001-systemd-services.patch
@@ -1,0 +1,36 @@
+diff -ru shadowsocks-libev-orig/debian/shadowsocks-libev.default shadowsocks-libev/debian/shadowsocks-libev.default
+--- shadowsocks-libev-orig/debian/shadowsocks-libev.default	2017-06-02 08:45:07.000000000 +0800
++++ shadowsocks-libev/debian/shadowsocks-libev.default	2017-06-28 16:39:37.236474413 +0800
+@@ -19,7 +19,7 @@
+ 
+ # User and group to run the server as
+ USER=nobody
+-GROUP=nogroup
++GROUP=nobody
+ 
+ # Number of maximum file descriptors
+ MAXFD=32768
+diff -ru shadowsocks-libev-orig/debian/shadowsocks-libev.service shadowsocks-libev/debian/shadowsocks-libev.service
+--- shadowsocks-libev-orig/debian/shadowsocks-libev.service	2017-06-02 08:45:07.000000000 +0800
++++ shadowsocks-libev/debian/shadowsocks-libev.service	2017-06-28 17:23:55.131822730 +0800
+@@ -6,7 +6,7 @@
+ #  (at your option) any later version.
+ #
+ #  This file is default for Debian packaging. See also
+-#  /etc/default/shadowsocks-libev for environment variables.
++#  /etc/sysconfig/shadowsocks-libev for environment variables.
+ 
+ [Unit]
+ Description=Shadowsocks-libev Default Server Service
+@@ -15,9 +15,9 @@
+ 
+ [Service]
+ Type=simple
+-EnvironmentFile=/etc/default/shadowsocks-libev
++EnvironmentFile=/etc/sysconfig/shadowsocks-libev
+ User=nobody
+-Group=nogroup
++Group=nobody
+ LimitNOFILE=32768
+ ExecStart=/usr/bin/ss-server -c $CONFFILE $DAEMON_ARGS
+ 

--- a/rpm/SPECS/shadowsocks-libev.spec.in
+++ b/rpm/SPECS/shadowsocks-libev.spec.in
@@ -7,6 +7,7 @@ Group:		Applications/Internet
 License:	GPLv3+
 URL:		https://github.com/shadowsocks/%{name}
 Source0:	%{url}/archive/v%{version}.tar.gz
+Patch0:     0001-systemd-services.patch
 
 AutoReq:        no
 Conflicts:	    python-shadowsocks python3-shadowsocks
@@ -45,7 +46,7 @@ shadowsocks-libev is a lightweight secured scoks5 proxy for embedded devices and
 
 %prep
 %setup -q
-
+%patch0 -p1
 
 %build
 ./autogen.sh
@@ -65,9 +66,9 @@ mkdir -p %{buildroot}/etc/shadowsocks-libev
 mkdir -p %{buildroot}%{_initddir}
 install -m 755 %{_builddir}/%{buildsubdir}/rpm/SOURCES/etc/init.d/shadowsocks-libev %{buildroot}%{_initddir}/shadowsocks-libev
 %else
-mkdir -p %{buildroot}%{_sysconfdir}/default
+mkdir -p %{buildroot}%{_sysconfdir}/sysconfig
 mkdir -p %{buildroot}%{_unitdir}
-install -m 644 %{_builddir}/%{buildsubdir}/debian/shadowsocks-libev.default %{buildroot}%{_sysconfdir}/default/shadowsocks-libev
+install -m 644 %{_builddir}/%{buildsubdir}/debian/shadowsocks-libev.default %{buildroot}%{_sysconfdir}/sysconfig/shadowsocks-libev
 install -m 644 %{_builddir}/%{buildsubdir}/debian/shadowsocks-libev.service %{buildroot}%{_unitdir}/shadowsocks-libev.service
 install -m 644 %{_builddir}/%{buildsubdir}/debian/shadowsocks-libev-*.service %{buildroot}%{_unitdir}/
 %endif
@@ -135,7 +136,7 @@ fi
 %else
 %{_unitdir}/shadowsocks-libev.service
 %{_unitdir}/shadowsocks-libev-*.service
-%config(noreplace) %{_sysconfdir}/default/shadowsocks-libev
+%config(noreplace) %{_sysconfdir}/sysconfig/shadowsocks-libev
 %endif
 
 %package devel


### PR DESCRIPTION
This patch is going to replace the group name 'nogroup' with 'nobody' in
debian/shadowsocks-libev.service for RPM based systems, and move file
'/etc/default/shadowsocks-libev' to '/etc/sysconfig/shadowsocks-libev'.

This is implemented by creating a text patch file. Not sure whether
there is a better approach.