### PR TITLE
Fix: ss-local and ss-redir should also respect ipv6_first.

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -1471,6 +1471,9 @@ main(int argc, char **argv)
             nofile = conf->nofile;
         }
 #endif
+        if (ipv6first == 0) {
+            ipv6first = conf->ipv6_first;
+        }
     }
 
     if (remote_num == 0 || remote_port == NULL ||

--- a/src/redir.c
+++ b/src/redir.c
@@ -1080,6 +1080,9 @@ main(int argc, char **argv)
             nofile = conf->nofile;
         }
 #endif
+        if (ipv6first == 0) {
+            ipv6first = conf->ipv6_first;
+        }
 	dscp_num = conf->dscp_num;
 	dscp = conf->dscp;
     }


### PR DESCRIPTION
Currently, ipv6_first entry in config is effective only for ss-server, but not for ss-local and ss-redir. Also no other config entry can enable ipv6 first option for ss-local or ss-redir.