### PR TITLE
Replace unchecked `malloc` with `ss_malloc`.

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -153,7 +153,7 @@ crypto_init(const char *password, const char *key, const char *method)
             cipher_t *cipher = stream_init(password, key, method);
             if (cipher == NULL)
                 return NULL;
-            crypto_t *crypto = (crypto_t *)malloc(sizeof(crypto_t));
+            crypto_t *crypto = (crypto_t *)ss_malloc(sizeof(crypto_t));
             crypto_t tmp     = {
                 .cipher      = cipher,
                 .encrypt_all = &stream_encrypt_all,

--- a/src/redir.c
+++ b/src/redir.c
@@ -1258,7 +1258,7 @@ main(int argc, char **argv)
 
         // Handle additionals TOS/DSCP listening ports
         if (dscp_num > 0) {
-            listen_ctx_current = (listen_ctx_t*) malloc(sizeof(listen_ctx_t));
+            listen_ctx_current = (listen_ctx_t*) ss_malloc(sizeof(listen_ctx_t));
             listen_ctx_current = memcpy(listen_ctx_current, &listen_ctx, sizeof(listen_ctx_t));
             local_port = dscp[dscp_num-1].port;
             listen_ctx_current->tos = dscp[dscp_num-1].dscp << 2;

--- a/src/server.c
+++ b/src/server.c
@@ -612,7 +612,7 @@ void setTosFromConnmark(remote_t* remote, server_t* server)
 			struct sockaddr_storage from_addr;
 			len = sizeof from_addr;
 			if(getpeername(remote->fd, (struct sockaddr*)&from_addr, &len) == 0) {
-				if((server->tracker = (struct dscptracker*) malloc(sizeof(struct dscptracker))))
+				if((server->tracker = (struct dscptracker*) ss_malloc(sizeof(struct dscptracker))))
 				{
 					if ((server->tracker->ct = nfct_new())) {
 						// Build conntrack query SELECT


### PR DESCRIPTION
In a few places `malloc` was being used without checking the return for
a `NULL` pointer. There's already a wrapper (`ss_malloc`) in
`util.c` that performs this check and exits if it fails so this PR
replaces the unsafe `malloc`s with `ss_malloc`s.