### PR TITLE
Add missed package for Ubuntu Docker image building

### DIFF
--- a/src/acl.h
+++ b/src/acl.h
@@ -26,7 +26,7 @@
 #define BLACK_LIST 0
 #define WHITE_LIST 1
 
-#define MAX_TRIES  64
+#define MAX_TRIES  256
 #define MALICIOUS  8
 #define SUSPICIOUS 4
 #define BAD        2


### PR DESCRIPTION
Add missed package: ca-certificates, automake, libmbedtls-dev. 

Fix these errors:

- **ca-certificates missed**
  fatal: unable to access 'https://github.com/shadowsocks/shadowsocks-libev.git/': Problem with the SSL CA cert (path? access rights?) 

- **automake missed**
  Can't exec "aclocal": No such file or directory at /usr/share/autoconf/Autom4te/FileUtils.pm line 326.   
  autoreconf: failed to run aclocal: No such file or directory

- **libmbedtls-dev**
  checking for mbedtls_cipher_setup in -lmbedcrypto... no
  configure: error: mbed TLS libraries not found.
