### PR TITLE
Discards long ACL lines

### DIFF
--- a/src/acl.c
+++ b/src/acl.c
@@ -191,6 +191,23 @@ init_acl(const char *path)
     char buf[257];
     while (!feof(f))
         if (fgets(buf, 256, f)) {
+            // Discards the whole line if longer than 255 characters
+            int long_line = 0;  // 1: Long  2: Error
+            while ((strlen(buf) == 255) && (buf[254] != '\n')) {
+                long_line = 1;
+                LOGE("Discarding long ACL content: %s", buf);
+                if (fgets(buf, 256, f) == NULL) {
+                    long_line = 2;
+                    break;
+                }
+            }
+            if (long_line) {
+                if (long_line == 1) {
+                    LOGE("Discarding long ACL content: %s", buf);
+                }
+                continue;
+            }
+
             // Trim the newline
             int len = strlen(buf);
             if (len > 0 && buf[len - 1] == '\n') {


### PR DESCRIPTION
Currently, there is a 255-character limit on ACL rules. A long ACL rule will be broken into several different rules, leading to surprising behaviors.

For example, there is an regular expression in the GFW List that is more than 900 characters, describing Google's various country specific domains. Making it a `proxy_list` ACL item:

    [bypass_all]

    [proxy_list]
    google\.(ac|ad|ae|al|am|as|at|az|ba|be|bf|bg|bi|bj|bs|bt|by|ca|cat|cd|cf|cg|ch|ci|cl|cm|co.ao|co.bw|co.ck|co.cr|co.id|co.il|co.in|co.jp|co.ke|co.kr|co.ls|co.ma|com|com.af|com.ag|com.ai|com.ar|com.au|com.bd|com.bh|com.bn|com.bo|com.br|com.bz|com.co|com.cu|com.cy|com.do|com.ec|com.eg|com.et|com.fj|com.gh|com.gi|com.gt|com.hk|com.jm|com.kh|com.kw|com.lb|com.ly|com.mm|com.mt|com.mx|com.my|com.na|com.nf|com.ng|com.ni|com.np|com.om|com.pa|com.pe|com.pg|com.ph|com.pk|com.pr|com.py|com.qa|com.sa|com.sb|com.sg|com.sl|com.sv|com.tj|com.tr|com.tw|com.ua|com.uy|com.vc|com.vn|co.mz|co.nz|co.th|co.tz|co.ug|co.uk|co.uz|co.ve|co.vi|co.za|co.zm|co.zw|cv|cz|de|dj|dk|dm|dz|ee|es|eu|fi|fm|fr|ga|ge|gg|gl|gm|gp|gr|gy|hk|hn|hr|ht|hu|ie|im|iq|is|it|je|jo|kg|ki|kz|la|li|lk|lt|lu|lv|md|me|mg|mk|ml|mn|ms|mu|mv|mw|mx|ne|nl|no|nr|nu|org|pl|pn|ps|pt|ro|rs|ru|rw|sc|se|sh|si|sk|sm|sn|so|sr|st|td|tg|tk|tl|tm|tn|to|tt|us|vg|vn|vu|ws)

This ACL file will make shadowsocks-libev proxy everything because the regular expression is being broken into four:

1. `google\.(ac|ad|ae|al|am|as|at|az|ba|be|bf|bg|bi|bj|bs|bt|by|ca|cat|cd|cf|cg|ch|ci|cl|cm|co.ao|co.bw|co.ck|co.cr|co.id|co.il|co.in|co.jp|co.ke|co.kr|co.ls|co.ma|com|com.af|com.ag|com.ai|com.ar|com.au|com.bd|com.bh|com.bn|com.bo|com.br|com.bz|com.co|com.cu|`
2. `com.cy|com.do|com.ec|com.eg|com.et|com.fj|com.gh|com.gi|com.gt|com.hk|com.jm|com.kh|com.kw|com.lb|com.ly|com.mm|com.mt|com.mx|com.my|com.na|com.nf|com.ng|com.ni|com.np|com.om|com.pa|com.pe|com.pg|com.ph|com.pk|com.pr|com.py|com.qa|com.sa|com.sb|com.sg|com`
3. `.sl|com.sv|com.tj|com.tr|com.tw|com.ua|com.uy|com.vc|com.vn|co.mz|co.nz|co.th|co.tz|co.ug|co.uk|co.uz|co.ve|co.vi|co.za|co.zm|co.zw|cv|cz|de|dj|dk|dm|dz|ee|es|eu|fi|fm|fr|ga|ge|gg|gl|gm|gp|gr|gy|hk|hn|hr|ht|hu|ie|im|iq|is|it|je|jo|kg|ki|kz|la|li|lk|lt|lu|`
4. `lv|md|me|mg|mk|ml|mn|ms|mu|mv|mw|mx|ne|nl|no|nr|nu|org|pl|pn|ps|pt|ro|rs|ru|rw|sc|se|sh|si|sk|sm|sn|so|sr|st|td|tg|tk|tl|tm|tn|to|tt|us|vg|vn|vu|ws)`

The first and fourth regexps are invalid because of the mismatching parentheses. The third one, unfortunately, is valid and is stopping at `|`, making an empty sub regular expression. Thus, matching every hostname.

---

Given the 255-character limit, the safest way of fixing this seems to be discarding the whole line if it is too long.