### PR TITLE
Update README and build_deb since libsodium 1.0.13 is backported

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ try `configure --help`.
 
 Shadowsocks-libev is available in the official repository for following distributions:
 
-* Debian 8 or higher (including oldstable, stable, testing and unstable/sid)
+* Debian 8 or higher, including oldstable (jessie), stable (stretch), testing (buster) and unstable (sid)
 * Ubuntu 16.10 or higher
 
 ```bash
@@ -82,7 +82,8 @@ We strongly encourage you to install shadowsocks-libev from `jessie-backports-sl
 For more info about backports, you can refer [Debian Backports](https://backports.debian.org).
 
 ```bash
-sudo sh -c 'printf "deb http://deb.debian.org/debian jessie-backports-sloppy main" > /etc/apt/sources.list.d/jessie-backports.list'
+sudo sh -c 'printf "deb http://deb.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list'
+sudo sh -c 'printf "deb http://deb.debian.org/debian jessie-backports-sloppy main" >> /etc/apt/sources.list.d/jessie-backports.list'
 sudo apt update
 sudo apt -t jessie-backports-sloppy install shadowsocks-libev
 ```
@@ -126,7 +127,7 @@ Please try to build and install directly from source. See the [Linux](#linux) se
 
 **Note for Debian 8 (Jessie) users to build their own deb packages**:
 
-We strongly encourage you to install shadowsocks-libev from `jessie-backports-sloppy`. If you insist on building from source, you will need to manually install libsodium from `jessie-backports`, **NOT** libsodium in main repository.
+We strongly encourage you to install shadowsocks-libev from `jessie-backports-sloppy`. If you insist on building from source, you will need to manually install libsodium from `jessie-backports-sloppy`, **NOT** libsodium in main repository.
 
 For more info about backports, you can refer [Debian Backports](https://backports.debian.org).
 

--- a/scripts/build_deb.sh
+++ b/scripts/build_deb.sh
@@ -199,8 +199,9 @@ if [ $BUILD_LIB -eq 1 -o $BUILD_BIN -eq 1 ]; then
 		if dpkg --compare-versions $DHVER lt 10; then
 			sed -i 's/debhelper ( >= 10)/debhelper (>= 9), dh-autoreconf/' debian/control;
 			echo 9 > debian/compat;
+			dch -D unstable -l~bpo~ "Rebuild as backports"
 			git add -u;
-			git commit -m "Patch to work with ubuntu trusty (14.04)"
+			git commit -m "Patch to work with ubuntu"
 		fi
 		mk-build-deps --root-cmd sudo --install --tool "apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y"
 		rm libsodium-build-deps_*.deb
@@ -238,6 +239,7 @@ if [ $BUILD_BIN -eq 1 ]; then
 	sed -i 's/dh $@/dh $@ --with systemd,autoreconf/' debian/rules
 	sed -i 's/debhelper (>= 10)/debhelper (>= 9), dh-systemd, dh-autoreconf/' debian/control
 	echo 9 > debian/compat
+	dch -D unstable -l~bpo~ "Rebuild as backports"
 	git add -u
 	git commit -m "Patch to work with ubuntu trusty (14.04)"
 	cd -
@@ -302,6 +304,7 @@ if [ $BUILD_KCP -eq 1 ]; then
 	cd golang-github-urfave-cli
 	[ -n "$BRANCH" ] && git checkout $BRANCH
 	sed -i 's/golang-github-burntsushi-toml-dev/golang-toml-dev/; s/golang-gopkg-yaml.v2-dev/golang-yaml.v2-dev/' debian/control
+	dch -D unstable -l~bpo~ "Rebuild as backports"
 	git add -u
 	git commit -m "Patch to work with ubuntu xenial (16.04)"
 	cd -
@@ -439,11 +442,7 @@ esac
 wheezy|precise)
 	echo Sorry, your system $OSID/$OSVER is not supported.
 	;;
-buster|testing|unstable|sid)
-	build_install_sslibev
-	;;
-jessie|stretch)
-	build_install_libsodium
+jessie|stretch|buster|testing|unstable|sid)
 	build_install_sslibev
 	;;
 zesty)


### PR DESCRIPTION
libsodium 1.0.13 is current in Debian apt repository of:
 - stretch-backports
 - jessie-backports-sloppy