### PR TITLE
Refine SPEC for RPM packages

### DIFF
--- a/rpm/SOURCES/systemd/shadowsocks-libev.default
+++ b/rpm/SOURCES/systemd/shadowsocks-libev.default
@@ -1,6 +1,6 @@
 # Defaults for shadowsocks initscript
 # sourced by /etc/init.d/shadowsocks-libev
-# installed at /etc/default/shadowsocks-libev by the maintainer scripts
+# installed at /etc/sysconfig/shadowsocks-libev by the maintainer scripts
 
 #
 # This is a POSIX shell fragment

--- a/rpm/SPECS/shadowsocks-libev.spec.in
+++ b/rpm/SPECS/shadowsocks-libev.spec.in
@@ -1,33 +1,39 @@
-Name:		shadowsocks-libev
-Version:	VERSION
-Release:	1%{?dist}
-Summary:	A lightweight and secure socks5 proxy
-
-Group:		Applications/Internet
-License:	GPLv3+
-URL:		https://github.com/shadowsocks/%{name}
-Source0:	%{url}/archive/v%{version}.tar.gz
-
-AutoReq:        no
-Conflicts:	    python-shadowsocks python3-shadowsocks
-BuildRequires:	make gcc pcre-devel asciidoc xmlto automake libtool mbedtls-devel libsodium-devel >= 1.0.4 libev-devel udns-devel
-Requires:       pcre mbedtls libsodium >= 1.0.4
-Requires:       libev udns
-
-
-%if 0%{?suse_version}
-Requires:       libopenssl1_0_0
-BuildRequires:  libopenssl-devel
-%else
-Requires:       openssl
-BuildRequires:  openssl-devel
+%global requires   pcre openssl mbedtls libsodium >= 1.0.4 libev udns
+%global conflicts  python-shadowsocks python3-shadowsocks
+%if 0%{?fedora} || 0%{?rhel}
+%global requires   %{?requires} libcap
 %endif
+%if 0%{?suse_version}
+%global requires   %{?requires} libcap-progs
+%endif
+%global project_desc shadowsocks-libev is a lightweight secured scoks5 proxy for embedded devices and low end boxes.
 
 %if 0%{?fedora} >= 15 || 0%{?rhel} >=7 || 0%{?suse_version} >= 1210
 %global use_systemd 1
 %else
 %global use_systemd 0
 %endif
+
+Name:	    	shadowsocks-libev
+Version:	    VERSION
+Release:	    1%{?dist}
+Summary:	    A lightweight and secure socks5 proxy
+
+Group:		    Applications/Internet
+License:	    GPLv3+
+URL:		    https://github.com/shadowsocks/%{name}
+Source0:	    %{url}/archive/v%{version}.tar.gz
+
+BuildRequires:	make gcc pcre-devel asciidoc xmlto automake libtool mbedtls-devel libsodium-devel >= 1.0.4 libev-devel udns-devel
+%if 0%{?suse_version}
+BuildRequires:  libopenssl-devel
+%else
+BuildRequires:  openssl-devel
+%endif
+
+AutoReq:        no
+Conflicts:	    %{?conflicts}
+Requires:       %{?requires}
 
 %if 0%{?use_systemd}
 %{?systemd_requires}
@@ -38,10 +44,8 @@ BuildRequires:   systemd
 %endif
 %endif
 
-
 %description
-shadowsocks-libev is a lightweight secured scoks5 proxy for embedded devices and low end boxes.
-
+%{?project_desc}
 
 %prep
 %setup -q
@@ -73,6 +77,8 @@ install -m 644 %{_builddir}/%{buildsubdir}/debian/config.json %{buildroot}%{_sys
 
 mkdir -p %{buildroot}%{_datadir}/bash-completion/completions/
 install -m 644 %{_builddir}/%{buildsubdir}/completions/bash/* %{buildroot}%{_datadir}/bash-completion/completions/
+mkdir -p %{buildroot}%{_datadir}/zsh/site-functions/
+install -m 644 %{_builddir}/%{buildsubdir}/completions/zsh/* %{buildroot}%{_datadir}/zsh/site-functions/
 
 %pre
 %if 0%{?use_systemd} && 0%{?suse_version}
@@ -80,7 +86,6 @@ install -m 644 %{_builddir}/%{buildsubdir}/completions/bash/* %{buildroot}%{_dat
 %endif
 
 %post
-/sbin/ldconfig
 %if ! 0%{?use_systemd}
 /sbin/chkconfig --add shadowsocks-libev > /dev/null 2>&1 || :
 %else
@@ -90,6 +95,10 @@ install -m 644 %{_builddir}/%{buildsubdir}/completions/bash/* %{buildroot}%{_dat
 %systemd_post shadowsocks-libev.service
 %endif
 %endif
+setcap cap_net_bind_service+ep %{_bindir}/ss-local \
+       cap_net_bind_service,cap_net_admin+ep %{_bindir}/ss-redir \
+       cap_net_bind_service+ep %{_bindir}/ss-server \
+       cap_net_bind_service+ep %{_bindir}/ss-tunnel
 
 %preun
 %if ! 0%{?use_systemd}
@@ -100,34 +109,47 @@ fi
 %else
 %if 0%{?suse_version}
 %service_del_preun shadowsocks-libev.service
+%service_del_preun shadowsocks-libev-local.service
 %else
 %systemd_preun shadowsocks-libev.service
+%systemd_preun shadowsocks-libev-local.service
+if [ $1 -eq 0 ] ; then
+    # Package removal, not upgrade
+    systemctl stop shadowsocks-libev-server@'*'.service  > /dev/null 2>&1 || :
+    systemctl stop shadowsocks-libev-local@'*'.service  > /dev/null 2>&1 || :
+    systemctl stop shadowsocks-libev-tunnel@'*'.service  > /dev/null 2>&1 || :
+    systemctl stop shadowsocks-libev-redir@'*'.service  > /dev/null 2>&1 || :
+    systemctl --no-reload disable shadowsocks-libev-server@.service  > /dev/null 2>&1 || :
+    systemctl --no-reload disable shadowsocks-libev-local@.service  > /dev/null 2>&1 || :
+    systemctl --no-reload disable shadowsocks-libev-tunnel@.service  > /dev/null 2>&1 || :
+    systemctl --no-reload disable shadowsocks-libev-redir@.service  > /dev/null 2>&1 || :
+fi
 %endif
 %endif
 
 %postun
-/sbin/ldconfig
 %if 0%{?use_systemd}
 %if 0%{?suse_version}
 %service_del_postun shadowsocks-libev.service
 %else
 %systemd_postun_with_restart shadowsocks-libev.service
+%systemd_postun_with_restart shadowsocks-libev-local.service
+%systemd_postun_with_restart shadowsocks-libev-server@'*'.service
+%systemd_postun_with_restart shadowsocks-libev-local@'*'.service
+%systemd_postun_with_restart shadowsocks-libev-tunnel@'*'.service
+%systemd_postun_with_restart shadowsocks-libev-redir@'*'.service
 %endif
 %endif
 
 %files
-/usr/share/doc/shadowsocks-libev/shadowsocks-libev.html
-/usr/share/doc/shadowsocks-libev/ss-local.html
-/usr/share/doc/shadowsocks-libev/ss-manager.html
-/usr/share/doc/shadowsocks-libev/ss-nat.html
-/usr/share/doc/shadowsocks-libev/ss-redir.html
-/usr/share/doc/shadowsocks-libev/ss-server.html
-/usr/share/doc/shadowsocks-libev/ss-tunnel.html
+%doc %{_docdir}/shadowsocks-libev/*.html
+%exclude %{_docdir}/shadowsocks-libev/ss-nat.html
 %{_bindir}/*
-%{_libdir}/*.so.*
+%exclude %{_bindir}/ss-nat
 %config(noreplace) %{_sysconfdir}/shadowsocks-libev/config.json
 %{_datadir}/bash-completion/completions/*
-%doc %{_mandir}/*
+%doc %{_mandir}/man*/*
+%exclude %{_mandir}/man1/ss-nat.1.*
 %if ! 0%{?use_systemd}
 %{_initddir}/shadowsocks-libev
 %else
@@ -135,20 +157,52 @@ fi
 %config(noreplace) %{_sysconfdir}/sysconfig/shadowsocks-libev
 %endif
 
-%package devel
+
+%package -n libshadowsocks-libev
+Summary:        %{?summary} (shared library)
+AutoReq:        no
+Requires:       pcre openssl mbedtls libsodium >= 1.0.4 libev udns
+
+%description -n libshadowsocks-libev
+Shared library powered by shadowsocks-libev.
+%{?project_desc}
+
+%files -n libshadowsocks-libev
+%{_libdir}/*.so.*
+
+%post -n libshadowsocks-libev
+/sbin/ldconfig
+
+%postun -n libshadowsocks-libev
+/sbin/ldconfig
+
+
+%package -n libshadowsocks-libev-devel
 Summary:    Development files for shadowsocks-libev
-Group:      Applications/Internet
-License:    GPLv3+
-Requires:   shadowsocks-libev == %{version}-%{release}
+Provides:   shadowsocks-libev-devel = %{version}-%{release}
+Requires:   libshadowsocks-libev = %{version}-%{release}
+Obsoletes:  shadowsocks-libev-devel < %{version}-%{release}
 
-%description devel
-Development files for shadowsocks-libev
+%description -n libshadowsocks-libev-devel
+Development files for libshadowsocks-libev.
+%{?project_desc}
 
-%files devel
+%files -n libshadowsocks-libev-devel
 %{_includedir}/*
 %{_libdir}/pkgconfig/*.pc
 %{_libdir}/libshadowsocks-libev.la
 %{_libdir}/libshadowsocks-libev.so
+
+%package zsh-completion
+Summary:        This package installs zsh completion files for shadowsocks-libev.
+Requires:       zsh shadowsocks-libev = %{version}-%{release}
+
+%description zsh-completion
+zsh completion files for shadowsocks-libev.
+%{?project_desc}
+
+%files zsh-completion
+%{_datadir}/zsh/site-functions/*
 
 %changelog
 


### PR DESCRIPTION
This change includes:

1. Move shared library `shadowsocks-libev.so.*` to an package `libshadowsocks-libev`
and rename package `shadowsocks-libev-devel` to `libshadowsocks-libev-devel`
to reconcile with the deb packages.
2. Add a new package `shadowsocks-libev-zsh-completion`.
3. Run `setcap` after installation (similar to #1119).
4. Remove ss-nat because it is designed for OpenWrt/LEDE.
5. Auto restart instantiated services after update and stop/disable instantiated
services after uninstallation.