### PR TITLE
ss-local: properly handle SOCKS5

### DIFF
--- a/src/socks5.h
+++ b/src/socks5.h
@@ -28,6 +28,8 @@
 #define IPV4 0x01
 #define DOMAIN 0x03
 #define IPV6 0x04
+#define METHOD_NOAUTH 0x00
+#define METHOD_UNACCEPTABLE 0xff
 #define CMD_NOT_SUPPORTED 0x07
 
 struct method_select_request {


### PR DESCRIPTION
 * close the connection if the client doesn't speak SOCKS5
 * check if client supports "no auth. required"