### PR TITLE
always set recv_ctx->connected

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -955,8 +955,8 @@ remote_recv_cb(EV_P_ ev_io *w, int revents)
         int opt = 0;
         setsockopt(server->fd, SOL_TCP, TCP_NODELAY, &opt, sizeof(opt));
         setsockopt(remote->fd, SOL_TCP, TCP_NODELAY, &opt, sizeof(opt));
-        remote->recv_ctx->connected = 1;
     }
+    remote->recv_ctx->connected = 1;
 }
 
 static void

--- a/src/redir.c
+++ b/src/redir.c
@@ -442,8 +442,8 @@ remote_recv_cb(EV_P_ ev_io *w, int revents)
         int opt = 0;
         setsockopt(server->fd, SOL_TCP, TCP_NODELAY, &opt, sizeof(opt));
         setsockopt(remote->fd, SOL_TCP, TCP_NODELAY, &opt, sizeof(opt));
-        remote->recv_ctx->connected = 1;
     }
+    remote->recv_ctx->connected = 1;
 }
 
 static void

--- a/src/server.c
+++ b/src/server.c
@@ -1147,8 +1147,8 @@ remote_recv_cb(EV_P_ ev_io *w, int revents)
         int opt = 0;
         setsockopt(server->fd, SOL_TCP, TCP_NODELAY, &opt, sizeof(opt));
         setsockopt(remote->fd, SOL_TCP, TCP_NODELAY, &opt, sizeof(opt));
-        remote->recv_ctx->connected = 1;
     }
+    remote->recv_ctx->connected = 1;
 }
 
 static void

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -382,8 +382,8 @@ remote_recv_cb(EV_P_ ev_io *w, int revents)
         int opt = 0;
         setsockopt(server->fd, SOL_TCP, TCP_NODELAY, &opt, sizeof(opt));
         setsockopt(remote->fd, SOL_TCP, TCP_NODELAY, &opt, sizeof(opt));
-        remote->recv_ctx->connected = 1;
     }
+    remote->recv_ctx->connected = 1;
 }
 
 static void


### PR DESCRIPTION
If no_delay is set to 1, recv_ctx->connected never gets set to 1.

Currently, recv_ctx->connected is only checked for the purpose of disabling NO_DELAY, so the problem fixed by this patch is entirely benign. Future modifications to shadowsocks might find some other use for recv_ctx->connected, however.