### PR TITLE
add multi-configuration script

### DIFF
--- a/scripts/multi-configuration scripts/README.md
+++ b/scripts/multi-configuration scripts/README.md
@@ -1,0 +1,11 @@
+This script is used to configure multi-ports using multi-configuration files. It uses systemd to manage multiple shadowsocks-libev processes, so in theory it will work on any Linux distribution that has systemd.
+
+Usage:
+---
+
+You need have Python3 installed on your system, you can check it out by using ```python3 --version```.
+
+The usage is pretty simple: just like original systemctl.
+
+1. put your configuration files in ```/etc/shadowsocks-libev/```
+2. use commands like systemctl ```python3 ss.py start|restart|stop|enable|disable|status```

--- a/scripts/multi-configuration scripts/ss.py
+++ b/scripts/multi-configuration scripts/ss.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+#-*- coding:utf-8 -*-
+
+import sys, subprocess, os
+
+commands = 'start restart stop enable disable status'.split()
+if len(sys.argv) != 2 or sys.argv[1] not in commands:
+    print('Usage: ss.py {}'.format('|'.join(commands)))
+else:
+    conf_dir = '/etc/shadowsocks-libev/'
+    filenames = [
+        os.path.splitext(filename)[0] for filename in os.listdir(conf_dir)
+        if os.path.splitext(filename)[1] == '.json'
+        and os.path.isfile(conf_dir + filename)
+    ]
+    for name in filenames:
+        command = "systemctl {} shadowsocks-libev-server@{}".format(
+            sys.argv[1], name)
+        try:
+            subprocess.call(command.split(), shell=False)
+        except Exception as e:
+            print(e)


### PR DESCRIPTION
This script is used to configure multiple ports using multiple configuration files in a easy way. It's useful to manage multiple shadowsocks-libev processes.