### PR TITLE
A minor change to let it getting on automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For **Ubuntu 14.04 and 16.04** users, please install from PPA:
 
 ```bash
 sudo apt-get install software-properties-common -y
-sudo add-apt-repository ppa:max-c-lv/shadowsocks-libev
+sudo add-apt-repository ppa:max-c-lv/shadowsocks-libev -y
 sudo apt-get update
 sudo apt install shadowsocks-libev
 ```


### PR DESCRIPTION
The command will be terminated if the parameter `-y` isn't following in ubuntu 16.04 TLS. (The command following will not executed when pasting the command queue of "[installing from PPA](https://github.com/shadowsocks/shadowsocks-libev#install-from-repository) for Ubuntu 14.04 and 16.04 users" into ssh terminal.)