### PR TITLE
Add support for new TFO API introduced from linux kernel 4.11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,7 +139,7 @@ AM_CONDITIONAL(BUILD_REDIRECTOR, test "$os_support" = "linux")
 AM_CONDITIONAL(BUILD_WINCOMPAT, test "$os_support" = "mingw")
 
 dnl Checks for header files.
-AC_CHECK_HEADERS([limits.h stdint.h inttypes.h arpa/inet.h fcntl.h langinfo.h locale.h netdb.h netinet/in.h stdlib.h string.h strings.h unistd.h sys/ioctl.h linux/random.h])
+AC_CHECK_HEADERS([limits.h stdint.h inttypes.h arpa/inet.h fcntl.h langinfo.h locale.h linux/tcp.h netinet/tcp.h netdb.h netinet/in.h stdlib.h string.h strings.h unistd.h sys/ioctl.h linux/random.h])
 
 dnl A special check required for <net/if.h> on Darwin. See
 dnl http://www.gnu.org/software/autoconf/manual/html_node/Header-Portability.html.

--- a/src/netutils.h
+++ b/src/netutils.h
@@ -25,27 +25,14 @@
 
 #include <sys/socket.h>
 
-#if defined(__linux__)
-#include <netdb.h>
-#else
+#ifdef HAVE_LINUX_TCP_H
+#include <linux/tcp.h>
+#elif defined(HAVE_NETINET_TCP_H)
 #include <netinet/tcp.h>
 #endif
 
-// only enable TCP_FASTOPEN on linux
-#if defined(__linux__)
-#include <linux/tcp.h>
-/*  conditional define for TCP_FASTOPEN */
-#ifndef TCP_FASTOPEN
-#define TCP_FASTOPEN   23
-#endif
-/*  conditional define for MSG_FASTOPEN */
-#ifndef MSG_FASTOPEN
-#define MSG_FASTOPEN   0x20000000
-#endif
-#elif !defined(__APPLE__)
-#ifdef TCP_FASTOPEN
-#undef TCP_FASTOPEN
-#endif
+#ifdef HAVE_NETDB_H
+#include <netdb.h>
 #endif
 
 /* MPTCP_ENABLED setsockopt values for kernel 4 & 3, best behaviour to be independant of kernel version is to test from newest to the latest values */


### PR DESCRIPTION
- Added header checking via configure script
- Self defined symbol, e.g.: TCP_FASTOPEN, MSG_FASTOPEN has been removed
  don't cheat CPP and check them via headers
- new API only requires setsockopt before connecting, which replaces sendto()
  with MSG_FASTOPEN

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>