### PR TITLE
Remove libtool to fix alpine 3.7 docker bug

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -23,7 +23,6 @@ RUN set -ex && \
                                 build-base \
                                 curl \
                                 libev-dev \
-                                libtool \
                                 linux-headers \
                                 libsodium-dev \
                                 mbedtls-dev \


### PR DESCRIPTION
Alpine 3.7 libtool pkg depends on bash pkg, this caused the compile hangs at "checking that generated files are newer than configure...", after check [this thread](https://forums.docker.com/t/problem-of-hanging-autoreconf/41015/3), I remove libtool and it works.