### PR TITLE
LIB_ONLY improvements

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -1733,7 +1733,7 @@ main(int argc, char **argv)
 #else
 
 int
-start_ss_local_server(profile_t profile)
+start_ss_local_server(profile_t profile, ss_local_callback init_callback, void *udata)
 {
     srand(time(NULL));
 
@@ -1841,6 +1841,10 @@ start_ss_local_server(profile_t profile)
 
     // Init connections
     cork_dllist_init(&connections);
+
+    if (init_callback) {
+        init_callback(listen_ctx.fd, udp_fd, udata);
+    }
 
     // Enter the loop
     ev_run(loop, 0);

--- a/src/shadowsocks.h
+++ b/src/shadowsocks.h
@@ -64,18 +64,23 @@ typedef struct {
 extern "C" {
 #endif
 
+typedef void (*ss_local_callback) (int socks_fd, int udp_fd, void *data);
+
 /*
  * Create and start a shadowsocks local server.
  *
  * Calling this function will block the current thread forever if the server
  * starts successfully.
  *
+ * init_callback is invoked when the local server has started successfully. It passes the SOCKS
+ * server and UDP relay file descriptors, along with any supplied user data.
+ *
  * Make sure start the server in a separate process to avoid any potential
  * memory and socket leak.
  *
  * If failed, -1 is returned. Errors will output to the log file.
  */
-int start_ss_local_server(profile_t profile);
+int start_ss_local_server(profile_t profile, ss_local_callback init_callback, void *udata);
 
 #ifdef __cplusplus
 }

--- a/src/udprelay.c
+++ b/src/udprelay.c
@@ -1383,8 +1383,8 @@ void
 free_udprelay()
 {
     struct ev_loop *loop = EV_DEFAULT;
-    while (server_num-- > 0) {
-        server_ctx_t *server_ctx = server_ctx_list[server_num];
+    while (server_num > 0) {
+        server_ctx_t *server_ctx = server_ctx_list[--server_num];
         ev_io_stop(loop, &server_ctx->io);
         close(server_ctx->fd);
         cache_delete(server_ctx->conn_cache, 0);


### PR DESCRIPTION
* Adds a callback to the Shadowsocks library interface. The function is called with the SOCKS server and UDP relay listen file descriptors. This is mainly for use in sandboxed iOS and macOS applications, where it is not possible to start ss-local as a process.
* Fixes an off-by-one bug in `udp_relay` that would result in a crash when LIB_ONLY is enabled.