### PR TITLE
LIB_ONLY improvements

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -1722,7 +1722,7 @@ main(int argc, char **argv)
 #else
 
 int
-start_ss_local_server(profile_t profile)
+_start_ss_local_server(profile_t profile, ss_local_callback callback, void *udata)
 {
     srand(time(NULL));
 
@@ -1831,6 +1831,10 @@ start_ss_local_server(profile_t profile)
     // Init connections
     cork_dllist_init(&connections);
 
+    if (callback) {
+        callback(listen_ctx.fd, udp_fd, udata);
+    }
+
     // Enter the loop
     ev_run(loop, 0);
 
@@ -1850,6 +1854,18 @@ start_ss_local_server(profile_t profile)
     }
 
     return 0;
+}
+
+int
+start_ss_local_server(profile_t profile)
+{
+    return _start_ss_local_server(profile, NULL, NULL);
+}
+
+int
+start_ss_local_server_with_callback(profile_t profile, ss_local_callback callback, void *udata)
+{
+    return _start_ss_local_server(profile, callback, udata);
 }
 
 #endif

--- a/src/shadowsocks.h
+++ b/src/shadowsocks.h
@@ -64,6 +64,8 @@ typedef struct {
 extern "C" {
 #endif
 
+typedef void (*ss_local_callback) (int socks_fd, int udp_fd, void *data);
+
 /*
  * Create and start a shadowsocks local server.
  *
@@ -76,6 +78,16 @@ extern "C" {
  * If failed, -1 is returned. Errors will output to the log file.
  */
 int start_ss_local_server(profile_t profile);
+
+/*
+ * Create and start a shadowsocks local server, specifying a callback.
+ *
+ * The callback is invoked when the local server has started successfully. It passes the SOCKS
+ * server and UDP relay file descriptors, along with any supplied user data.
+ *
+ * Returns -1 on failure.
+ */
+int start_ss_local_server_with_callback(profile_t profile, ss_local_callback callback, void *udata);
 
 #ifdef __cplusplus
 }

--- a/src/udprelay.c
+++ b/src/udprelay.c
@@ -1383,8 +1383,8 @@ void
 free_udprelay()
 {
     struct ev_loop *loop = EV_DEFAULT;
-    while (server_num-- > 0) {
-        server_ctx_t *server_ctx = server_ctx_list[server_num];
+    while (server_num > 0) {
+        server_ctx_t *server_ctx = server_ctx_list[--server_num];
         ev_io_stop(loop, &server_ctx->io);
         close(server_ctx->fd);
         cache_delete(server_ctx->conn_cache, 0);


### PR DESCRIPTION
* Adds a Shadowsocks library interface to start `ss-local` with a callback. The function is called with the SOCKS server and UDP relay listen file descriptors. This is mainly for use in sandboxed iOS and macOS applications, where it is not possible to start `ss-local` as a process.
* Fixes an off-by-one bug in udp_relay that would result in a crash when LIB_ONLY is enabled.
* Supersedes #1829.