### PR TITLE
tests: Change the port to listen from 8388 to 8389

### DIFF
--- a/tests/aes-ctr.json
+++ b/tests/aes-ctr.json
@@ -1,6 +1,6 @@
 {
     "server":"127.0.0.1",
-    "server_port":8388,
+    "server_port":8389,
     "local_port":1081,
     "password":"aes_password",
     "timeout":60,

--- a/tests/aes-gcm.json
+++ b/tests/aes-gcm.json
@@ -1,6 +1,6 @@
 {
     "server":"127.0.0.1",
-    "server_port":8388,
+    "server_port":8389,
     "local_port":1081,
     "password":"aes_password",
     "timeout":60,

--- a/tests/aes.json
+++ b/tests/aes.json
@@ -1,6 +1,6 @@
 {
     "server":"127.0.0.1",
-    "server_port":8388,
+    "server_port":8389,
     "local_port":1081,
     "password":"aes_password",
     "timeout":60,

--- a/tests/chacha20-ietf-poly1305.json
+++ b/tests/chacha20-ietf-poly1305.json
@@ -1,6 +1,6 @@
 {
     "server":"127.0.0.1",
-    "server_port":8388,
+    "server_port":8389,
     "local_port":1081,
     "password":"salsa20_password",
     "timeout":60,

--- a/tests/chacha20-ietf.json
+++ b/tests/chacha20-ietf.json
@@ -1,6 +1,6 @@
 {
     "server":"127.0.0.1",
-    "server_port":8388,
+    "server_port":8389,
     "local_port":1081,
     "password":"salsa20_password",
     "timeout":60,

--- a/tests/chacha20.json
+++ b/tests/chacha20.json
@@ -1,6 +1,6 @@
 {
     "server":"127.0.0.1",
-    "server_port":8388,
+    "server_port":8389,
     "local_port":1081,
     "password":"chacha20_password",
     "timeout":60,

--- a/tests/rc4-md5.json
+++ b/tests/rc4-md5.json
@@ -1,6 +1,6 @@
 {
     "server":"127.0.0.1",
-    "server_port":8388,
+    "server_port":8389,
     "local_port":1081,
     "password":"aes_password",
     "timeout":60,

--- a/tests/salsa20.json
+++ b/tests/salsa20.json
@@ -1,6 +1,6 @@
 {
     "server":"127.0.0.1",
-    "server_port":8388,
+    "server_port":8389,
     "local_port":1081,
     "password":"salsa20_password",
     "timeout":60,


### PR DESCRIPTION
8388 is already taken by default config, so for test suites it's
better to choose a different port.