### PR TITLE
Make cmake to build under Debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ endif ()
 message(STATUS "Running cmake version ${CMAKE_VERSION}")
 
 option(WITH_STATIC "build with static libraries." ON)
+option(WITH_EMBEDDED_SRC "build with embedded libcork, libipset, and libbloom source." ON)
 
 # Will set GIT_EXECUTABLE and GIT_FOUND
 # find_package(Git)
@@ -51,6 +52,7 @@ install(FILES
         DESTINATION pkgconfig
         )
 
+if (WITH_EMBEDDED_SRC)
 # We need libcork,libipset headers
 include_directories(libcork/include)
 include_directories(libipset/include)
@@ -137,6 +139,7 @@ endif ()
 add_library(bloom-shared SHARED ${LIBBLOOM_SOURCE})
 target_link_libraries(ipset-shared cork-shared bloom-shared)
 set_target_properties(bloom-shared PROPERTIES OUTPUT_NAME bloom)
+endif ()
 
 add_subdirectory(src)
 add_subdirectory(doc)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,17 +94,8 @@ find_library(LIBMBEDCRYPTO libmbedcrypto.a)
 find_library(LIBEV libev.a)
 find_library(LIBUDNS libcares.a)
 find_library(LIBPCRE libpcre.a)
-endif ()
-
-find_library(LIBSODIUM_SHARED sodium)
-find_library(LIBMBEDTLS_SHARED mbedtls)
-find_library(LIBMBEDCRYPTO_SHARED mbedcrypto)
-find_library(LIBEV_SHARED ev)
-find_library(LIBUDNS_SHARED cares)
-find_library(LIBPCRE_SHARED pcre)
 
 # Dependencies we need for static and shared
-if (WITH_STATIC)
 list(APPEND DEPS
         m
         bloom
@@ -117,9 +108,19 @@ list(APPEND DEPS
         )
 endif ()
 
+find_library(LIBSODIUM_SHARED sodium)
+find_library(LIBMBEDTLS_SHARED mbedtls)
+find_library(LIBMBEDCRYPTO_SHARED mbedcrypto)
+find_library(LIBEV_SHARED ev)
+find_library(LIBUDNS_SHARED cares)
+find_library(LIBPCRE_SHARED pcre)
+
+if (WITH_EMBEDDED_SRC)
 list(APPEND DEPS_SHARED
         m
         bloom-shared
+        cork-shared
+        ipset-shared
         ${LIBEV_SHARED}
         ${LIBUDNS_SHARED}
         ${LIBPCRE_SHARED}
@@ -127,6 +128,23 @@ list(APPEND DEPS_SHARED
         ${LIBMBEDTLS_SHARED}
         ${LIBMBEDCRYPTO_SHARED}
         )
+else ()
+find_library(LIBBLOOM_SHARED bloom)
+find_library(LIBCORK_SHARED cork)
+find_library(LIBCORKIPSET_SHARED corkipset)
+list(APPEND DEPS_SHARED
+        m
+        ${LIBBLOOM_SHARED}
+        ${LIBCORK_SHARED}
+        ${LIBCORKIPSET_SHARED}
+        ${LIBEV_SHARED}
+        ${LIBUDNS_SHARED}
+        ${LIBPCRE_SHARED}
+        ${LIBSODIUM_SHARED}
+        ${LIBMBEDTLS_SHARED}
+        ${LIBMBEDCRYPTO_SHARED}
+        )
+endif ()
 
 find_package (Threads)
 
@@ -184,12 +202,12 @@ target_compile_definitions(ss-local-shared PUBLIC -DMODULE_LOCAL)
 target_compile_definitions(ss-redir-shared PUBLIC -DMODULE_REDIR)
 target_compile_definitions(shadowsocks-libev-shared PUBLIC -DMODULE_LOCAL)
 
-target_link_libraries(ss-server-shared cork-shared ipset-shared ${DEPS_SHARED})
-target_link_libraries(ss-tunnel-shared cork-shared ${DEPS_SHARED})
-target_link_libraries(ss-manager-shared m bloom-shared cork-shared ${CMAKE_THREAD_LIBS_INIT} ${LIBEV_SHARED} ${LIBUDNS_SHARED})
-target_link_libraries(ss-local-shared cork-shared ipset-shared ${DEPS_SHARED})
-target_link_libraries(ss-redir-shared cork-shared ipset-shared ${DEPS_SHARED})
-target_link_libraries(shadowsocks-libev-shared cork-shared ipset-shared ${DEPS_SHARED})
+target_link_libraries(ss-server-shared ${DEPS_SHARED})
+target_link_libraries(ss-tunnel-shared ${DEPS_SHARED})
+target_link_libraries(ss-manager-shared ${CMAKE_THREAD_LIBS_INIT} ${LIBEV_SHARED} ${LIBUDNS_SHARED} ${DEPS_SHARED})
+target_link_libraries(ss-local-shared ${DEPS_SHARED})
+target_link_libraries(ss-redir-shared ${DEPS_SHARED})
+target_link_libraries(shadowsocks-libev-shared ${DEPS_SHARED})
 
 set_target_properties(ss-server-shared PROPERTIES OUTPUT_NAME ss-server)
 set_target_properties(ss-tunnel-shared PROPERTIES OUTPUT_NAME ss-tunnel)
@@ -204,7 +222,7 @@ set_target_properties(ss-server-shared ss-tunnel-shared ss-manager-shared ss-loc
 
 set_target_properties(shadowsocks-libev-shared PROPERTIES OUTPUT_NAME shadowsocks-libev)
 target_compile_definitions(shadowsocks-libev-shared PUBLIC -DMODULE_LOCAL)
-target_link_libraries(shadowsocks-libev-shared cork-shared ipset-shared ${DEPS_SHARED})
+target_link_libraries(shadowsocks-libev-shared ${DEPS_SHARED})
 
 # ------------------------------------------------------------------
 # Misc


### PR DESCRIPTION
Add a new option, WITH_EMBEDDED_SRC, which default is ON and same as
current setting.
When set to OFF, it can use system's libcork, libcorkipset, and libbloom.

It can be built in debian by:
$ cmake -DUSE_SYSTEM_SHARED_LIB=1 -DWITH_STATIC=OFF -DWITH_EMBEDDED_SRC=OFF
$ make