### PR TITLE
update  shadowsocks-libev.service

### DIFF
--- a/rpm/SOURCES/systemd/shadowsocks-libev.service
+++ b/rpm/SOURCES/systemd/shadowsocks-libev.service
@@ -11,7 +11,7 @@
 [Unit]
 Description=Shadowsocks-libev Default Server Service
 Documentation=man:shadowsocks-libev(8)
-After=network.target
+After=network.target network-online.target 
 
 [Service]
 Type=simple


### PR DESCRIPTION
ss-server waits for local ip ready, add network-online.target here.

my env.
CentOS Linux release 7.2.1511 (Core)

orig. file doesnt work and failed on ip binding. add "network-online.target" to the after list. it works.

I guess it's not a generic issue, Im running centos 7.2 x64 vps. so I didnt replace "network.target" to  "network-online.target", keep the both items.