### PR TITLE
Update Dockerfile to utilize Docker Cloud auto build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# General
+.dockerignore
+.gitignore
+.github
+AUTHORS
+Changes
+COPYING
+INSTALL
+LICENSE
+README.md
+
+# Code formatting
+.uncrustify.cfg
+code-format.bat
+code-format.sh
+
+# CI & CD
+.travis.yml
+tests
+
+# OS-specific packaging, etc.
+debian
+scripts/build_deb.sh
+rpm
+completions

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -5,9 +5,6 @@
 FROM alpine
 MAINTAINER kev <noreply@datageek.info>
 
-ARG SS_VER=3.1.3
-ARG SS_URL=https://github.com/shadowsocks/shadowsocks-libev/releases/download/v$SS_VER/shadowsocks-libev-$SS_VER.tar.gz
-
 ENV SERVER_ADDR 0.0.0.0
 ENV SERVER_PORT 8388
 ENV PASSWORD=
@@ -17,23 +14,26 @@ ENV DNS_ADDR    8.8.8.8
 ENV DNS_ADDR_2  8.8.4.4
 ENV ARGS=
 
+COPY . /tmp
+
 RUN set -ex && \
     apk add --no-cache --virtual .build-deps \
+                                git \
                                 autoconf \
+                                automake \
+                                libtool \
                                 build-base \
-                                curl \
                                 libev-dev \
                                 linux-headers \
                                 libsodium-dev \
                                 mbedtls-dev \
                                 pcre-dev \
-                                tar \
                                 c-ares-dev && \
     cd /tmp && \
-    curl -sSL $SS_URL | tar xz --strip 1 && \
+    git submodule update --init --recursive && \
+    ./autogen.sh && \
     ./configure --prefix=/usr --disable-documentation && \
     make install && \
-    cd .. && \
 
     runDeps="$( \
         scanelf --needed --nobanner /usr/bin/ss-* \


### PR DESCRIPTION
* Use the repository as context, instead of released .tar.gz
* Remove version information from Dockerfile, and let Docker Cloud handle it
* Add .dockerignore

Next steps:

1. Connect repository in Docker Cloud
2. Setup automated builds:
   - A push on `master` branch triggers build for `unstable` tag
   - A tag matching `/^v[0-9]+(\.[0-9]+){2}$/` triggers build for a same-named tag

Refer to #1914