### PR TITLE
Fixed: run time permission are not configurable

### DIFF
--- a/debian/shadowsocks-libev.service
+++ b/debian/shadowsocks-libev.service
@@ -16,8 +16,8 @@ After=network.target
 [Service]
 Type=simple
 EnvironmentFile=/etc/default/shadowsocks-libev
-User=nobody
-Group=nogroup
+User=$USER
+Group=$GROUP
 LimitNOFILE=32768
 ExecStart=/usr/bin/ss-server -c $CONFFILE $DAEMON_ARGS
 


### PR DESCRIPTION
Active run time permission configured in `/etc/default/shadowsocks-libev`.