### PR TITLE
Re-add MinGW compilation support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,7 @@ dnl Add library for mingw
 case $host in
   *-mingw*)
     CFLAGS="$CFLAGS -mno-ms-bitfields"
-    LIBS="$LIBS -ladvapi32 -lgdi32 -lws2_32 -lcrypt32"
+    LIBS="$LIBS -lws2_32"
     ;;
   *-cygwin*)
     CFLAGS="$CFLAGS -mno-ms-bitfields"
@@ -92,6 +92,10 @@ case $host in
   *-linux*)
     os_support=linux
     AC_MSG_RESULT(Linux)
+    ;;
+  *-mingw*)
+    os_support=mingw
+    AC_MSG_RESULT(MinGW)
     ;;
   *)
     AC_MSG_RESULT(transparent proxy does not support for $host)
@@ -161,6 +165,10 @@ AC_CHECK_HEADERS([net/if.h], [], [],
 ])
 
 case $host in
+  *-mingw*)
+    AC_DEFINE([CONNECT_IN_PROGRESS], [WSAEWOULDBLOCK], [errno for incomplete non-blocking connect(2)])
+    AC_CHECK_HEADERS([winsock2.h ws2tcpip.h], [], [AC_MSG_ERROR([Missing MinGW headers])], [])
+    ;;
   *-linux*)
     AC_DEFINE([CONNECT_IN_PROGRESS], [EINPROGRESS], [errno for incomplete non-blocking connect(2)])
     dnl Checks for netfilter headers
@@ -219,6 +227,12 @@ AC_CHECK_LIB(socket, connect)
 dnl Checks for library functions.
 AC_CHECK_FUNCS([malloc memset posix_memalign socket])
 
+AC_ARG_WITH(ev,
+  AS_HELP_STRING([--with-ev=DIR], [use a specific libev library]),
+  [CFLAGS="$CFLAGS -I$withval/include"
+   CPPFLAGS="$CPPFLAGS -I$withval/include"
+   LDFLAGS="$LDFLAGS -L$withval/lib"]
+)
 AC_CHECK_HEADERS([ev.h libev/ev.h], [], [])
 AC_CHECK_LIB([ev], [ev_loop_destroy], [LIBS="-lev $LIBS"], [AC_MSG_ERROR([Couldn't find libev. Try installing libev-dev@<:@el@:>@.])])
 

--- a/docker/mingw/Dockerfile
+++ b/docker/mingw/Dockerfile
@@ -1,0 +1,42 @@
+#
+# Dockerfile for building MinGW port
+#
+# This file is part of the shadowsocks-libev.
+#
+# shadowsocks-libev is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# shadowsocks-libev is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with shadowsocks-libev; see the file COPYING. If not, see
+# <http://www.gnu.org/licenses/>.
+#
+
+FROM debian:testing
+
+ARG REPO=shadowsocks
+ARG REV=master
+
+ADD prepare.sh /
+
+RUN \
+  /bin/bash -c "source /prepare.sh && dk_prepare" && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /build
+
+RUN /bin/bash -c "source /prepare.sh && dk_download"
+
+ADD deps.sh /
+RUN /bin/bash -c "source /deps.sh && dk_deps"
+
+ADD build.sh /
+
+ARG REBUILD=0
+
+RUN /bin/bash -c "source /build.sh && dk_build && dk_package"

--- a/docker/mingw/Makefile
+++ b/docker/mingw/Makefile
@@ -1,0 +1,38 @@
+#
+# Makefile for building MinGW port
+#
+# This file is part of the shadowsocks-libev.
+#
+# shadowsocks-libev is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# shadowsocks-libev is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with shadowsocks-libev; see the file COPYING. If not, see
+# <http://www.gnu.org/licenses/>.
+#
+
+REPO=shadowsocks
+REV=master
+IMAGE=ss-build-mingw
+DIST=ss-libev-win-dist.tar.gz
+
+all: build
+
+build:
+	docker build --force-rm -t $(IMAGE) \
+	  --build-arg REV=$(REV) --build-arg REPO=$(REPO) \
+	  --build-arg REBUILD="$$(date +%Y-%m-%d-%H-%M-%S)" .
+	docker run --rm --entrypoint cat $(IMAGE) /bin.tgz > $(DIST)
+
+clean:
+	rm -f $(DIST)
+	docker rmi $(IMAGE) || true
+
+.PHONY: all clean build

--- a/docker/mingw/build.sh
+++ b/docker/mingw/build.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# Functions for building MinGW port in Docker
+#
+# This file is part of the shadowsocks-libev.
+#
+# shadowsocks-libev is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# shadowsocks-libev is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with shadowsocks-libev; see the file COPYING. If not, see
+# <http://www.gnu.org/licenses/>.
+#
+
+# Exit on error
+set -e
+
+. /prepare.sh
+
+build_proj() {
+    arch=$1
+    host=$arch-w64-mingw32
+    prefix=${DIST}/$arch
+    dep=${PREFIX}/$arch
+
+    cd "$SRC"
+    git clone ${PROJ_URL} proj
+    cd proj
+    git checkout ${PROJ_REV}
+    git submodule update --init
+    ./autogen.sh
+    ./configure --host=${host} --prefix=${prefix} \
+      --disable-documentation \
+      --with-ev="$dep" \
+      --with-mbedtls="$dep" \
+      --with-sodium="$dep" \
+      --with-pcre="$dep" \
+      --with-cares="$dep" \
+      CFLAGS="-DCARES_STATICLIB -DPCRE_STATIC"
+    make clean
+    make LDFLAGS="-all-static -L${dep}/lib"
+    make install-strip
+}
+
+dk_build() {
+    for arch in i686 x86_64; do
+        build_proj $arch
+    done
+}
+
+dk_package() {
+    rm -rf "$BASE/pack"
+    mkdir -p "$BASE/pack"
+    cd "$BASE/pack"
+    mkdir -p ss-libev-${PROJ_REV}
+    cd ss-libev-${PROJ_REV}
+    for bin in local server tunnel; do
+        cp ${DIST}/i686/bin/ss-${bin}.exe ss-${bin}-x86.exe
+        cp ${DIST}/x86_64/bin/ss-${bin}.exe ss-${bin}-x64.exe
+    done
+    pushd "$SRC/proj"
+    GIT_REV="$(git rev-parse --short HEAD)"
+    popd
+    echo "SHA1 checksum for build $(date +"%y%m%d")-${GIT_REV}" > checksum
+    for f in *.exe; do
+        echo "  $f:" >> checksum
+        echo "    $(sha1sum $f | cut -d ' ' -f 1)" >> checksum
+    done
+    sed -e 's/$/\r/' checksum > checksum.txt
+    rm -f checksum
+    cd ..
+    tar zcf /bin.tgz ss-libev-${PROJ_REV}
+}

--- a/docker/mingw/deps.sh
+++ b/docker/mingw/deps.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Functions for building MinGW port in Docker
+#
+# This file is part of the shadowsocks-libev.
+#
+# shadowsocks-libev is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# shadowsocks-libev is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with shadowsocks-libev; see the file COPYING. If not, see
+# <http://www.gnu.org/licenses/>.
+#
+
+# Exit on error
+set -e
+
+. /prepare.sh
+
+build_deps() {
+    arch=$1
+    host=$arch-w64-mingw32
+    prefix=${PREFIX}/$arch
+    args="--host=${host} --prefix=${prefix} --disable-shared --enable-static"
+
+    # libev
+    cd "$SRC/$LIBEV_SRC"
+    ./configure $args
+    make clean
+    make install
+
+    # mbedtls
+    cd "$SRC/$MBEDTLS_SRC"
+    make clean
+    make lib WINDOWS=1 CC="${host}-gcc" AR="${host}-ar"
+    make install DESTDIR="${prefix}"
+
+    # sodium
+    cd "$SRC/$SODIUM_SRC"
+    ./configure $args
+    make clean
+    make install
+
+    # pcre
+    cd "$SRC/$PCRE_SRC"
+    ./configure $args \
+      --enable-jit --disable-cpp \
+      --enable-unicode-properties \
+      --enable-pcre16 --enable-pcre32
+    make clean
+    make install
+
+    # c-ares
+    cd "$SRC/$CARES_SRC"
+    ./configure $args
+    make clean
+    make install
+}
+
+dk_deps() {
+    for arch in i686 x86_64; do
+        build_deps $arch
+    done
+}

--- a/docker/mingw/prepare.sh
+++ b/docker/mingw/prepare.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# Functions for building MinGW port in Docker
+#
+# This file is part of the shadowsocks-libev.
+#
+# shadowsocks-libev is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# shadowsocks-libev is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with shadowsocks-libev; see the file COPYING. If not, see
+# <http://www.gnu.org/licenses/>.
+#
+
+# Exit on error
+set -e
+
+# Build options
+BASE="/build"
+PREFIX="$BASE/stage"
+SRC="$BASE/src"
+DIST="$BASE/dist"
+
+# Project URL
+PROJ_SITE=$REPO   # Change REPO in Makefile
+PROJ_REV=$REV     # Change REV in Makefile
+PROJ_URL=https://github.com/${PROJ_SITE}/shadowsocks-libev.git
+
+# Libraries from project
+
+## libev for MinGW
+LIBEV_VER=mingw
+LIBEV_SRC=libev-${LIBEV_VER}
+LIBEV_URL=https://github.com/${PROJ_SITE}/libev/archive/${LIBEV_VER}.tar.gz
+
+## mbedTLS for MinGW
+MBEDTLS_VER=mingw
+MBEDTLS_SRC=mbedtls-${MBEDTLS_VER}
+MBEDTLS_URL=https://github.com/${PROJ_SITE}/mbedtls/archive/${MBEDTLS_VER}.tar.gz
+
+# Public libraries
+
+## Sodium
+SODIUM_VER=1.0.16
+SODIUM_SRC=libsodium-${SODIUM_VER}
+SODIUM_URL=https://download.libsodium.org/libsodium/releases/${SODIUM_SRC}.tar.gz
+
+## PCRE
+PCRE_VER=8.41
+PCRE_SRC=pcre-${PCRE_VER}
+PCRE_URL=https://ftp.pcre.org/pub/pcre/${PCRE_SRC}.tar.gz
+
+## c-ares
+CARES_VER=1.14.0
+CARES_SRC=c-ares-${CARES_VER}
+CARES_URL=https://c-ares.haxx.se/download/${CARES_SRC}.tar.gz
+
+# Build steps
+
+dk_prepare() {
+    apt-get update -y
+    apt-get install --no-install-recommends -y \
+      mingw-w64 aria2 git make automake autoconf libtool ca-certificates
+}
+
+dk_download() {
+    mkdir -p "${SRC}"
+    cd "${SRC}"
+    DOWN="aria2c --file-allocation=trunc -s10 -x10 -j10 -c"
+    for pkg in LIBEV SODIUM MBEDTLS PCRE CARES; do
+        src=${pkg}_SRC
+        url=${pkg}_URL
+        out="${!src}".tar.gz
+        $DOWN ${!url} -o "${out}"
+        echo "Unpacking ${out}..."
+        tar zxf ${out}
+    done
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,7 +19,10 @@ SS_COMMON_LIBS += -lbloom -lcork -lcorkipset
 endif
 SS_COMMON_LIBS += -lev -lsodium -lm
 
-bin_PROGRAMS = ss-local ss-tunnel ss-server ss-manager
+bin_PROGRAMS = ss-local ss-tunnel ss-server
+if !BUILD_WINCOMPAT
+bin_PROGRAMS += ss-manager
+endif
 
 sni_src = http.c \
           tls.c
@@ -30,41 +33,37 @@ acl_src = rule.c \
 crypto_src = crypto.c \
              aead.c \
              stream.c \
-			 ppbloom.c \
+             ppbloom.c \
              base64.c
 
 plugin_src = plugin.c
 
-ss_local_SOURCES = utils.c \
-                   jconf.c \
-                   json.c \
-                   udprelay.c \
-                   cache.c \
-                   netutils.c \
-                   local.c \
+common_src = utils.c \
+             jconf.c \
+             json.c \
+             udprelay.c \
+             cache.c \
+             netutils.c
+
+if BUILD_WINCOMPAT
+common_src += winsock.c
+endif
+
+ss_local_SOURCES = local.c \
+                   $(common_src) \
                    $(crypto_src) \
                    $(plugin_src) \
                    $(sni_src) \
                    $(acl_src)
 
-ss_tunnel_SOURCES = utils.c \
-                    jconf.c \
-                    json.c \
-                    udprelay.c \
-                    cache.c \
-                    netutils.c \
-                    tunnel.c \
+ss_tunnel_SOURCES = tunnel.c \
+                    $(common_src) \
                     $(crypto_src) \
                     $(plugin_src)
 
-ss_server_SOURCES = utils.c \
-                    netutils.c \
-                    jconf.c \
-                    json.c \
-                    udprelay.c \
-                    cache.c \
-                    resolv.c \
+ss_server_SOURCES = resolv.c \
                     server.c \
+                    $(common_src) \
                     $(crypto_src) \
                     $(plugin_src) \
                     $(sni_src) \

--- a/src/aead.c
+++ b/src/aead.c
@@ -31,11 +31,14 @@
 #include <assert.h>
 
 #include <sodium.h>
+#ifndef __MINGW32__
 #include <arpa/inet.h>
+#endif
 
 #include "ppbloom.h"
 #include "aead.h"
 #include "utils.h"
+#include "winsock.h"
 
 #define NONE                    (-1)
 #define AES128GCM               0

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -372,7 +372,7 @@ crypto_parse_key(const char *base64, uint8_t *key, size_t key_len)
     rand_bytes(key, key_len);
     base64_encode(out_key, out_len, key, key_len);
     LOGE("Invalid key for your chosen cipher!");
-    LOGE("It requires a %zu-byte key encoded with URL-safe Base64", key_len);
+    LOGE("It requires a " SIZE_FMT "-byte key encoded with URL-safe Base64", key_len);
     LOGE("Generating a new random key: %s", out_key);
     FATAL("Please use the key above or input a valid key");
     return key_len;

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -23,7 +23,9 @@
 #ifndef _CRYPTO_H
 #define _CRYPTO_H
 
+#ifndef __MINGW32__
 #include <sys/socket.h>
+#endif
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/json.c
+++ b/src/json.c
@@ -35,6 +35,12 @@
    #endif
 #endif
 
+#ifdef __MINGW32__
+#define CONV_PTR (uintptr_t)
+#else
+#define CONV_PTR (unsigned long)
+#endif
+
 const struct _json_value json_value_none;
 
 #include <stdio.h>
@@ -138,7 +144,7 @@ static int new_value (json_state * state,
             values_size = sizeof (*value->u.object.values) * value->u.object.length;
 
             if (! (value->u.object.values = (json_object_entry *) json_alloc
-                  (state, values_size + ((unsigned long) value->u.object.values), 0)) )
+                  (state, values_size + (CONV_PTR value->u.object.values), 0)) )
             {
                return 0;
             }

--- a/src/netutils.c
+++ b/src/netutils.c
@@ -28,10 +28,12 @@
 #include "config.h"
 #endif
 
+#ifndef __MINGW32__
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <unistd.h>
+#endif
 
 #if defined(HAVE_SYS_IOCTL_H) && defined(HAVE_NET_IF_H) && defined(__linux__)
 #include <net/if.h>

--- a/src/netutils.h
+++ b/src/netutils.h
@@ -23,7 +23,11 @@
 #ifndef _NETUTILS_H
 #define _NETUTILS_H
 
+#ifdef __MINGW32__
+#include "winsock.h"
+#else
 #include <sys/socket.h>
+#endif
 
 #ifdef HAVE_LINUX_TCP_H
 #include <linux/tcp.h>

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -24,6 +24,8 @@
 #include "config.h"
 #endif
 
+#ifndef __MINGW32__
+
 #include <string.h>
 #include <unistd.h>
 #include <sys/socket.h>
@@ -299,3 +301,5 @@ is_plugin_running()
     }
     return 0;
 }
+
+#endif

--- a/src/resolv.c
+++ b/src/resolv.c
@@ -32,13 +32,13 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
-
+#ifndef __MINGW32__
 #include <netdb.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <errno.h>
 #include <unistd.h>
-
+#endif
 #include <ares.h>
 
 #ifdef HAVE_LIBEV_EV_H
@@ -52,6 +52,13 @@
 #include "resolv.h"
 #include "utils.h"
 #include "netutils.h"
+#include "winsock.h"
+
+#ifdef __MINGW32__
+#define CONV_STATE_CB (ares_sock_state_cb)
+#else
+#define CONV_STATE_CB
+#endif
 
 /*
  * Implement DNS resolution interface using libc-ares
@@ -147,7 +154,7 @@ resolv_init(struct ev_loop *loop, char *nameservers, int ipv6first)
     memset(&default_ctx, 0, sizeof(struct resolv_ctx));
 
     default_ctx.options.sock_state_cb_data = &default_ctx;
-    default_ctx.options.sock_state_cb      = resolv_sock_state_cb;
+    default_ctx.options.sock_state_cb      = CONV_STATE_CB resolv_sock_state_cb;
     default_ctx.options.timeout            = 3000;
     default_ctx.options.tries              = 2;
 

--- a/src/resolv.h
+++ b/src/resolv.h
@@ -31,7 +31,9 @@
 #endif
 
 #include <stdint.h>
+#ifndef __MINGW32__
 #include <sys/socket.h>
+#endif
 
 struct resolv_query;
 

--- a/src/stream.h
+++ b/src/stream.h
@@ -23,7 +23,9 @@
 #ifndef _STREAM_H
 #define _STREAM_H
 
+#ifndef __MINGW32__
 #include <sys/socket.h>
+#endif
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/tls.c
+++ b/src/tls.c
@@ -36,7 +36,9 @@
 #include <stdio.h>
 #include <stdlib.h> /* malloc() */
 #include <string.h> /* strncpy() */
+#ifndef __MINGW32__
 #include <sys/socket.h>
+#endif
 
 #include "tls.h"
 #include "protocol.h"

--- a/src/udprelay.c
+++ b/src/udprelay.c
@@ -29,13 +29,13 @@
 #include <strings.h>
 #include <time.h>
 #include <unistd.h>
-
+#ifndef __MINGW32__
 #include <arpa/inet.h>
 #include <errno.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <pthread.h>
-
+#endif
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -52,6 +52,7 @@
 #include "netutils.h"
 #include "cache.h"
 #include "udprelay.h"
+#include "winsock.h"
 
 #ifdef MODULE_REMOTE
 #define MAX_UDP_CONN_NUM 512
@@ -105,6 +106,7 @@ static int buf_size                                  = DEFAULT_PACKET_SIZE * 2;
 static int server_num                                = 0;
 static server_ctx_t *server_ctx_list[MAX_REMOTE_NUM] = { NULL };
 
+#ifndef __MINGW32__
 static int
 setnonblocking(int fd)
 {
@@ -114,6 +116,7 @@ setnonblocking(int fd)
     }
     return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
 }
+#endif
 
 #if defined(MODULE_REMOTE) && defined(SO_BROADCAST)
 static int
@@ -724,7 +727,7 @@ remote_recv_cb(EV_P_ ev_io *w, int revents)
         goto CLEAN_UP;
     } else if (r > packet_size) {
         if (verbose) {
-            LOGI("[udp] remote_recv_recvfrom fragmentation, MTU at least be: %zd", r + PACKET_HEADER_SIZE);
+            LOGI("[udp] remote_recv_recvfrom fragmentation, MTU at least be: " SSIZE_FMT, r + PACKET_HEADER_SIZE);
         }
     }
 
@@ -798,7 +801,7 @@ remote_recv_cb(EV_P_ ev_io *w, int revents)
 
     if (buf->len > packet_size) {
         if (verbose) {
-            LOGI("[udp] remote_recv_sendto fragmentation, MTU at least be: %zd", buf->len + PACKET_HEADER_SIZE);
+            LOGI("[udp] remote_recv_sendto fragmentation, MTU at least be: " SSIZE_FMT, buf->len + PACKET_HEADER_SIZE);
         }
     }
 
@@ -902,7 +905,7 @@ server_recv_cb(EV_P_ ev_io *w, int revents)
         goto CLEAN_UP;
     } else if (buf->len > packet_size) {
         if (verbose) {
-            LOGI("[udp] UDP server_recv_recvmsg fragmentation, MTU at least be: %zd", buf->len + PACKET_HEADER_SIZE);
+            LOGI("[udp] UDP server_recv_recvmsg fragmentation, MTU at least be: " SSIZE_FMT, buf->len + PACKET_HEADER_SIZE);
         }
     }
 
@@ -924,7 +927,7 @@ server_recv_cb(EV_P_ ev_io *w, int revents)
         goto CLEAN_UP;
     } else if (r > packet_size) {
         if (verbose) {
-            LOGI("[udp] server_recv_recvfrom fragmentation, MTU at least be: %zd", r + PACKET_HEADER_SIZE);
+            LOGI("[udp] server_recv_recvfrom fragmentation, MTU at least be: " SSIZE_FMT, r + PACKET_HEADER_SIZE);
         }
     }
 
@@ -1208,7 +1211,7 @@ server_recv_cb(EV_P_ ev_io *w, int revents)
 
     if (buf->len > packet_size) {
         if (verbose) {
-            LOGI("[udp] server_recv_sendto fragmentation, MTU at least be: %zd", buf->len + PACKET_HEADER_SIZE);
+            LOGI("[udp] server_recv_sendto fragmentation, MTU at least be: " SSIZE_FMT, buf->len + PACKET_HEADER_SIZE);
         }
     }
 
@@ -1225,7 +1228,7 @@ server_recv_cb(EV_P_ ev_io *w, int revents)
 
     if (buf->len - addr_header_len > packet_size) {
         if (verbose) {
-            LOGI("[udp] server_recv_sendto fragmentation, MTU at least be: %zd", buf->len - addr_header_len + PACKET_HEADER_SIZE);
+            LOGI("[udp] server_recv_sendto fragmentation, MTU at least be: " SSIZE_FMT, buf->len - addr_header_len + PACKET_HEADER_SIZE);
         }
     }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -25,12 +25,14 @@
 #endif
 
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
-#include <errno.h>
 #include <ctype.h>
+#ifndef __MINGW32__
+#include <unistd.h>
+#include <errno.h>
 #include <pwd.h>
 #include <grp.h>
+#endif
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -55,12 +57,14 @@ FILE *logfile;
 int use_syslog = 0;
 #endif
 
+#ifndef __MINGW32__
 void
 ERROR(const char *s)
 {
     char *msg = strerror(errno);
     LOGE("%s: %s", s, msg);
 }
+#endif
 
 int use_tty = 1;
 
@@ -102,6 +106,7 @@ ss_isnumeric(const char *s)
 int
 run_as(const char *user)
 {
+#ifndef __MINGW32__
     if (user[0]) {
         /* Convert user to a long integer if it is a non-negative number.
          * -1 means it is a user name. */
@@ -195,6 +200,9 @@ run_as(const char *user)
         }
 #endif
     }
+#else
+    LOGE("run_as(): not implemented in MinGW port");
+#endif
 
     return 1;
 }
@@ -400,6 +408,7 @@ usage()
 void
 daemonize(const char *path)
 {
+#ifndef __MINGW32__
     /* Our process ID and Session ID */
     pid_t pid, sid;
 
@@ -444,6 +453,9 @@ daemonize(const char *path)
     close(STDIN_FILENO);
     close(STDOUT_FILENO);
     close(STDERR_FILENO);
+#else
+    LOGE("daemonize(): not implemented in MinGW port");
+#endif
 }
 
 #ifdef HAVE_SETRLIMIT
@@ -478,6 +490,7 @@ set_nofile(int nofile)
 char *
 get_default_conf(void)
 {
+#ifndef __MINGW32__
     static char sysconf[] = "/etc/shadowsocks-libev/config.json";
     static char userconf[PATH_MAX] = { 0 };
     char *conf_home;
@@ -498,4 +511,7 @@ get_default_conf(void)
 
     // If not, fall back to the system-wide config.
     return sysconf;
+#else
+    return "config.json";
+#endif
 }

--- a/src/winsock.c
+++ b/src/winsock.c
@@ -1,0 +1,75 @@
+/*
+ * winsock.c - Windows socket compatibility layer
+ *
+ * Copyright (C) 2013 - 2018, Max Lv <max.c.lv@gmail.com>
+ *
+ * This file is part of the shadowsocks-libev.
+ *
+ * shadowsocks-libev is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * shadowsocks-libev is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with shadowsocks-libev; see the file COPYING. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef __MINGW32__
+
+#include "winsock.h"
+#include "utils.h"
+
+void
+winsock_init(void)
+{
+    int ret;
+    WSADATA wsa_data;
+    ret = WSAStartup(MAKEWORD(2, 2), &wsa_data);
+    if (ret != 0) {
+        FATAL("Failed to initialize winsock");
+    }
+}
+
+void
+winsock_cleanup(void)
+{
+    WSACleanup();
+}
+
+int
+setnonblocking(SOCKET socket)
+{
+    u_long arg = 1;
+    return ioctlsocket(socket, FIONBIO, &arg);
+}
+
+void
+ss_error(const char *s)
+{
+    char *msg = NULL;
+    DWORD err = WSAGetLastError();
+    FormatMessage(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER |
+        FORMAT_MESSAGE_FROM_SYSTEM |
+        FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL, err,
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        (LPTSTR)&msg, 0, NULL);
+    if (msg != NULL) {
+        // Remove trailing newline character
+        ssize_t len = strlen(msg) - 1;
+        if (len >= 0 && msg[len] == '\n') {
+            msg[len] = '\0';
+        }
+        LOGE("%s: [%ld] %s", s, err, msg);
+        LocalFree(msg);
+    }
+}
+
+#endif // __MINGW32__

--- a/src/winsock.h
+++ b/src/winsock.h
@@ -1,0 +1,86 @@
+/*
+ * winsock.h - Windows socket compatibility layer
+ *
+ * Copyright (C) 2013 - 2018, Max Lv <max.c.lv@gmail.com>
+ *
+ * This file is part of the shadowsocks-libev.
+ *
+ * shadowsocks-libev is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * shadowsocks-libev is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with shadowsocks-libev; see the file COPYING. If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _WINSOCK_H
+#define _WINSOCK_H
+
+#ifdef __MINGW32__
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0600
+#undef _WIN32_WINNT
+#endif
+
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
+
+#include <windows.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+// Override error number
+#ifdef errno
+#undef errno
+#endif
+#define errno WSAGetLastError()
+
+#ifdef EWOULDBLOCK
+#undef EWOULDBLOCK
+#endif
+#define EWOULDBLOCK WSAEWOULDBLOCK
+
+#ifdef CONNECT_IN_PROGRESS
+#undef CONNECT_IN_PROGRESS
+#endif
+#define CONNECT_IN_PROGRESS WSAEWOULDBLOCK
+
+// Override close function
+#define close(fd) closesocket(fd)
+
+// Override MinGW functions
+#define setsockopt(a,b,c,d,e) setsockopt(a,b,c,(const char *)(d),e)
+#define inet_ntop(a,b,c,d) inet_ntop(a,(void *)(b),c,d)
+
+// Override Windows built-in functions
+#ifdef ERROR
+#undef ERROR
+#endif
+#define ERROR(s) ss_error(s)
+#ifndef _UTILS_H
+void ss_error(const char *s);
+#endif
+
+// Missing unistd.h functions
+#define sleep(x) Sleep((x) * 1000)
+
+// Winsock compatibility functions
+int setnonblocking(SOCKET socket);
+void winsock_init(void);
+void winsock_cleanup(void);
+
+#endif // __MINGW32__
+
+#endif // _WINSOCK_H


### PR DESCRIPTION
This pull request re-adds support for building against MinGW-w64. It also includes a Dockerfile in `docker/mingw` for easy compilation with Docker.

### Why do we re-add the MinGW support?

The main reason is that I found an efficient way to use **libev** library on Windows. With the support of [piscisaureus/wepoll](https://github.com/piscisaureus/wepoll) project by @piscisaureus, we can finally use efficient IOCP events instead of `select()`. So we can also enable building `ss-server` on Windows. There are still some minor issues with LSP (Layered Service Provider) support in wepoll (see piscisaureus/wepoll#5). Many applications use LSP, such as Proxifier or some game accelerators, and may interfere with wepoll. The current [patch](https://github.com/linusyang92/libev/commit/93499c3dbfb79c8a8fb378dce1f3e47b14a4ef85) is working but less efficient. We can use this patch for now and wait for further patches of wepoll.

### Why support MinGW as we already support Cygwin or WSL?

Cygwin can only use `select()` as backend for libev library, which is less efficient than wepoll that uses IOCP. And wepoll only supports Windows socket, which is incompatible with Cygwin's BSD socket emulation layer. WSL works perfectly but only on Windows 10. It would be better if we can have a native Windows port.

### What is not supported in MinGW port?

* __plugins__: Plugin support on Windows requires significant effort because Windows uses a very different process model from POSIX. We may implement this on Windows in the future.
* __daemon features__ (`ss-manager`): Similar reasons.

### How to build MinGW port using Docker?

The command is simple:
```
cd docker/mingw && make
```

The generated binaries for both 32-bit and 64-bit architectures will be compressed in a tarball in the same directory. A checksum file will also be included.

Notice that this Docker script does not work at the moment until the following third-party libraries are patched accordingly:

* Included in the repository:
  * __libcork__: Fix MinGW build: linusyang92/libcork@70ab3aae7b3624364ace64bf430479a166c6d53b
* Organization repos: (create a new `mingw` branch for patches)
  * __libev__: Add wepoll as backend: linusyang92/libev@5001e8e033cb999e1160c828e420a19dbb001bc2 (and [more in the `mingw`](https://github.com/linusyang92/libev/commits/mingw) branch)
  * __mbedtls__: Fix `make install` command: linusyang92/mbedtls@a68625401312ae10b9d0310d47bf9c88222aa4a6

I will make pull requests for these repos when they have a separate `mingw` branch. For now, you can use my branch [here](https://github.com/linusyang92/shadowsocks-libev/tree/mingw) to build MinGW port which already uses patched third-party libraries.

### Is it harmful to re-support MinGW? Does it increase the maintenance effort?

I would like to say no to both questions. It takes us very little effort to support Windows. So why not? From version 3.0 of this project, the MinGW support was removed because of significant changes of code. It *was* a burden of maintenance because the old MinGW port is always broken. It supports NT5 (Windows XP) which is quite outdated, and some BSD socket functions are missing. In this patch, we drop the support of NT5 and only support NT6 or above (i.e. Windows Vista or above). This could make the life easier and is also the requirement of wepoll library. The compatibility layer is very thin and placed in a single file (`winsock.c`) which is easy to maintain. We also add a Docker script to automatically build the MinGW port. Any developer can quickly check if his changes break the MinGW port.