### PR TITLE
Fix MinGW build using Docker

### DIFF
--- a/docker/mingw/deps.sh
+++ b/docker/mingw/deps.sh
@@ -40,7 +40,15 @@ build_deps() {
     cd "$SRC/$MBEDTLS_SRC"
     make clean
     make lib WINDOWS=1 CC="${host}-gcc" AR="${host}-ar"
-    make install DESTDIR="${prefix}"
+    ## "make install" command from mbedtls
+    DESTDIR="${prefix}"
+    mkdir -p "${DESTDIR}"/include/mbedtls
+    cp -r include/mbedtls "${DESTDIR}"/include
+    mkdir -p "${DESTDIR}"/lib
+    cp -RP library/libmbedtls.*    "${DESTDIR}"/lib
+    cp -RP library/libmbedx509.*   "${DESTDIR}"/lib
+    cp -RP library/libmbedcrypto.* "${DESTDIR}"/lib
+    unset DESTDIR
 
     # sodium
     cd "$SRC/$SODIUM_SRC"

--- a/docker/mingw/prepare.sh
+++ b/docker/mingw/prepare.sh
@@ -40,12 +40,12 @@ LIBEV_VER=mingw
 LIBEV_SRC=libev-${LIBEV_VER}
 LIBEV_URL=https://github.com/${PROJ_SITE}/libev/archive/${LIBEV_VER}.tar.gz
 
-## mbedTLS for MinGW
-MBEDTLS_VER=mingw
-MBEDTLS_SRC=mbedtls-${MBEDTLS_VER}
-MBEDTLS_URL=https://github.com/${PROJ_SITE}/mbedtls/archive/${MBEDTLS_VER}.tar.gz
-
 # Public libraries
+
+## mbedTLS
+MBEDTLS_VER=2.7.0
+MBEDTLS_SRC=mbedtls-${MBEDTLS_VER}
+MBEDTLS_URL=https://tls.mbed.org/download/mbedtls-${MBEDTLS_VER}-apache.tgz
 
 ## Sodium
 SODIUM_VER=1.0.16


### PR DESCRIPTION
Please refer to discussion at shadowsocks/shadowsocks-libev/pull/1962.

This patch updates libcork submodule to support MinGW build and also modifies the Docker scripts to support build using official mbedtls releases.

The docker script will work when shadowsocks/libev#3 is merged into a new branched called `mingw`.