### PR TITLE
Support TCP fast open on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,7 @@ AC_CHECK_HEADERS([net/if.h], [], [],
 case $host in
   *-mingw*)
     AC_DEFINE([CONNECT_IN_PROGRESS], [WSAEWOULDBLOCK], [errno for incomplete non-blocking connect(2)])
-    AC_CHECK_HEADERS([winsock2.h ws2tcpip.h], [], [AC_MSG_ERROR([Missing MinGW headers])], [])
+    AC_CHECK_HEADERS([winsock2.h ws2tcpip.h mswsock.h], [], [AC_MSG_ERROR([Missing MinGW headers])], [])
     ;;
   *-linux*)
     AC_DEFINE([CONNECT_IN_PROGRESS], [EINPROGRESS], [errno for incomplete non-blocking connect(2)])

--- a/src/local.c
+++ b/src/local.c
@@ -384,14 +384,13 @@ server_recv_cb(EV_P_ ev_io *w, int revents)
                         if(setsockopt(remote->fd, IPPROTO_TCP, TCP_FASTOPEN,
                                       &optval, sizeof(optval)) != 0) {
                             ERROR("setsockopt");
-                            err = WSAEOPNOTSUPP;
                             break;
                         }
                         // Load ConnectEx function
                         LPFN_CONNECTEX ConnectEx = winsock_getconnectex();
                         if (ConnectEx == NULL) {
                             LOGE("Cannot load ConnectEx() function");
-                            err = WSAEOPNOTSUPP;
+                            err = WSAENOPROTOOPT;
                             break;
                         }
                         // ConnectEx requires a bound socket

--- a/src/local.c
+++ b/src/local.c
@@ -371,11 +371,57 @@ server_recv_cb(EV_P_ ev_io *w, int revents)
                     ev_io_start(EV_A_ & remote->send_ctx->io);
                     ev_timer_start(EV_A_ & remote->send_ctx->watcher);
                 } else {
-                    int s = -1;
 #if defined(MSG_FASTOPEN) && !defined(TCP_FASTOPEN_CONNECT)
+                    int s = -1;
                     s = sendto(remote->fd, remote->buf->data, remote->buf->len, MSG_FASTOPEN,
                                    (struct sockaddr *)&(remote->addr), remote->addr_len);
+#elif defined(TCP_FASTOPEN_WINSOCK)
+                    DWORD s = -1;
+                    DWORD err = 0;
+                    do {
+                        int optval = 1;
+                        // Set fast open option
+                        if(setsockopt(remote->fd, IPPROTO_TCP, TCP_FASTOPEN,
+                                      &optval, sizeof(optval)) != 0) {
+                            ERROR("setsockopt");
+                            err = WSAEOPNOTSUPP;
+                            break;
+                        }
+                        // Load ConnectEx function
+                        LPFN_CONNECTEX ConnectEx = winsock_getconnectex();
+                        if (ConnectEx == NULL) {
+                            LOGE("Cannot load ConnectEx() function");
+                            err = WSAEOPNOTSUPP;
+                            break;
+                        }
+                        // ConnectEx requires a bound socket
+                        if (winsock_dummybind(remote->fd,
+                                              (struct sockaddr *)&(remote->addr)) != 0) {
+                            ERROR("bind");
+                            break;
+                        }
+                        // Call ConnectEx to send data
+                        memset(&remote->olap, 0, sizeof(remote->olap));
+                        remote->connect_ex_done = 0;
+                        if (ConnectEx(remote->fd, (const struct sockaddr *)&(remote->addr),
+                                      remote->addr_len, remote->buf->data, remote->buf->len,
+                                      &s, &remote->olap)) {
+                            remote->connect_ex_done = 1;
+                            break;
+                        };
+                        // XXX: ConnectEx pending, check later in remote_send
+                        if (WSAGetLastError() == ERROR_IO_PENDING) {
+                            err = CONNECT_IN_PROGRESS;
+                            break;
+                        }
+                        ERROR("ConnectEx");
+                    } while(0);
+                    // Set error number
+                    if (err) {
+                        SetLastError(err);
+                    }
 #else
+                    int s = -1;
 #if defined(CONNECT_DATA_IDEMPOTENT)
                     ((struct sockaddr_in *)&(remote->addr))->sin_len = sizeof(struct sockaddr_in);
                     sa_endpoints_t endpoints;
@@ -958,6 +1004,37 @@ remote_send_cb(EV_P_ ev_io *w, int revents)
     server_t *server              = remote->server;
 
     if (!remote_send_ctx->connected) {
+#ifdef TCP_FASTOPEN_WINSOCK
+        if (fast_open) {
+            // Check if ConnectEx is done
+            if (!remote->connect_ex_done) {
+                DWORD numBytes;
+                DWORD flags;
+                // Non-blocking way to fetch ConnectEx result
+                if (WSAGetOverlappedResult(remote->fd, &remote->olap,
+                                           &numBytes, FALSE, &flags)) {
+                    remote->buf->len -= numBytes;
+                    remote->buf->idx  = numBytes;
+                    remote->connect_ex_done = 1;
+                } else if (WSAGetLastError() == WSA_IO_INCOMPLETE) {
+                    // XXX: ConnectEx still not connected, wait for next time
+                    return;
+                } else {
+                    ERROR("WSAGetOverlappedResult");
+                    // not connected
+                    close_and_free_remote(EV_A_ remote);
+                    close_and_free_server(EV_A_ server);
+                    return;
+                };
+            }
+
+            // Make getpeername work
+            if (setsockopt(remote->fd, SOL_SOCKET,
+                           SO_UPDATE_CONNECT_CONTEXT, NULL, 0) != 0) {
+                ERROR("setsockopt");
+            }
+        }
+#endif
         struct sockaddr_storage addr;
         socklen_t len = sizeof addr;
         int r         = getpeername(remote->fd, (struct sockaddr *)&addr, &len);

--- a/src/local.c
+++ b/src/local.c
@@ -381,8 +381,8 @@ server_recv_cb(EV_P_ ev_io *w, int revents)
                     do {
                         int optval = 1;
                         // Set fast open option
-                        if(setsockopt(remote->fd, IPPROTO_TCP, TCP_FASTOPEN,
-                                      &optval, sizeof(optval)) != 0) {
+                        if (setsockopt(remote->fd, IPPROTO_TCP, TCP_FASTOPEN,
+                                       &optval, sizeof(optval)) != 0) {
                             ERROR("setsockopt");
                             break;
                         }

--- a/src/local.h
+++ b/src/local.h
@@ -31,7 +31,7 @@
 #include <ev.h>
 #endif
 
-#ifdef TCP_FASTOPEN_WINSOCK
+#ifdef __MINGW32__
 #include "winsock.h"
 #endif
 

--- a/src/local.h
+++ b/src/local.h
@@ -31,6 +31,10 @@
 #include <ev.h>
 #endif
 
+#ifdef TCP_FASTOPEN_WINSOCK
+#include "winsock.h"
+#endif
+
 #include "crypto.h"
 #include "jconf.h"
 #include "protocol.h"
@@ -85,6 +89,10 @@ typedef struct remote {
     int direct;
     int addr_len;
     uint32_t counter;
+#ifdef TCP_FASTOPEN_WINSOCK
+    OVERLAPPED olap;
+    int connect_ex_done;
+#endif
 
     buffer_t *buf;
 

--- a/src/resolv.c
+++ b/src/resolv.c
@@ -38,6 +38,8 @@
 #include <netinet/in.h>
 #include <errno.h>
 #include <unistd.h>
+#else
+#include "winsock.h" // Should be before <ares.h>
 #endif
 #include <ares.h>
 
@@ -52,7 +54,6 @@
 #include "resolv.h"
 #include "utils.h"
 #include "netutils.h"
-#include "winsock.h"
 
 #ifdef __MINGW32__
 #define CONV_STATE_CB (ares_sock_state_cb)

--- a/src/server.c
+++ b/src/server.c
@@ -517,11 +517,56 @@ connect_to_remote(EV_P_ struct addrinfo *res,
     remote_t *remote = new_remote(sockfd);
 
     if (fast_open) {
-        int s = -1;
 #if defined(MSG_FASTOPEN) && !defined(TCP_FASTOPEN_CONNECT)
+        int s = -1;
         s = sendto(sockfd, server->buf->data, server->buf->len,
                 MSG_FASTOPEN, res->ai_addr, res->ai_addrlen);
+#elif defined(TCP_FASTOPEN_WINSOCK)
+        DWORD s = -1;
+        DWORD err = 0;
+        do {
+            int optval = 1;
+            // Set fast open option
+            if(setsockopt(sockfd, IPPROTO_TCP, TCP_FASTOPEN,
+                          &optval, sizeof(optval)) != 0) {
+                ERROR("setsockopt");
+                err = WSAEOPNOTSUPP;
+                break;
+            }
+            // Load ConnectEx function
+            LPFN_CONNECTEX ConnectEx = winsock_getconnectex();
+            if (ConnectEx == NULL) {
+                LOGE("Cannot load ConnectEx() function");
+                err = WSAEOPNOTSUPP;
+                break;
+            }
+            // ConnectEx requires a bound socket
+            if (winsock_dummybind(sockfd, res->ai_addr) != 0) {
+                ERROR("bind");
+                break;
+            }
+            // Call ConnectEx to send data
+            memset(&remote->olap, 0, sizeof(remote->olap));
+            remote->connect_ex_done = 0;
+            if (ConnectEx(sockfd, res->ai_addr, res->ai_addrlen,
+                          server->buf->data, server->buf->len,
+                          &s, &remote->olap)) {
+                remote->connect_ex_done = 1;
+                break;
+            };
+            // XXX: ConnectEx pending, check later in remote_send
+            if (WSAGetLastError() == ERROR_IO_PENDING) {
+                err = CONNECT_IN_PROGRESS;
+                break;
+            }
+            ERROR("ConnectEx");
+        } while(0);
+        // Set error number
+        if (err) {
+            SetLastError(err);
+        }
 #else
+        int s = -1;
 #if defined(TCP_FASTOPEN_CONNECT)
         int optval = 1;
         if(setsockopt(sockfd, IPPROTO_TCP, TCP_FASTOPEN_CONNECT,
@@ -1175,6 +1220,37 @@ remote_send_cb(EV_P_ ev_io *w, int revents)
     }
 
     if (!remote_send_ctx->connected) {
+#ifdef TCP_FASTOPEN_WINSOCK
+        if (fast_open) {
+            // Check if ConnectEx is done
+            if (!remote->connect_ex_done) {
+                DWORD numBytes;
+                DWORD flags;
+                // Non-blocking way to fetch ConnectEx result
+                if (WSAGetOverlappedResult(remote->fd, &remote->olap,
+                                           &numBytes, FALSE, &flags)) {
+                    remote->buf->len -= numBytes;
+                    remote->buf->idx  = numBytes;
+                    remote->connect_ex_done = 1;
+                } else if (WSAGetLastError() == WSA_IO_INCOMPLETE) {
+                    // XXX: ConnectEx still not connected, wait for next time
+                    return;
+                } else {
+                    ERROR("WSAGetOverlappedResult");
+                    // not connected
+                    close_and_free_remote(EV_A_ remote);
+                    close_and_free_server(EV_A_ server);
+                    return;
+                };
+            }
+
+            // Make getpeername work
+            if (setsockopt(remote->fd, SOL_SOCKET,
+                           SO_UPDATE_CONNECT_CONTEXT, NULL, 0) != 0) {
+                ERROR("setsockopt");
+            }
+        }
+#endif
         struct sockaddr_storage addr;
         socklen_t len = sizeof(struct sockaddr_storage);
         memset(&addr, 0, len);

--- a/src/server.c
+++ b/src/server.c
@@ -530,14 +530,13 @@ connect_to_remote(EV_P_ struct addrinfo *res,
             if(setsockopt(sockfd, IPPROTO_TCP, TCP_FASTOPEN,
                           &optval, sizeof(optval)) != 0) {
                 ERROR("setsockopt");
-                err = WSAEOPNOTSUPP;
                 break;
             }
             // Load ConnectEx function
             LPFN_CONNECTEX ConnectEx = winsock_getconnectex();
             if (ConnectEx == NULL) {
                 LOGE("Cannot load ConnectEx() function");
-                err = WSAEOPNOTSUPP;
+                err = WSAENOPROTOOPT;
                 break;
             }
             // ConnectEx requires a bound socket

--- a/src/server.c
+++ b/src/server.c
@@ -307,7 +307,7 @@ setfastopen(int fd)
     int s = 0;
 #ifdef TCP_FASTOPEN
     if (fast_open) {
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__MINGW32__)
         int opt = 1;
 #else
         int opt = 5;

--- a/src/server.c
+++ b/src/server.c
@@ -527,8 +527,8 @@ connect_to_remote(EV_P_ struct addrinfo *res,
         do {
             int optval = 1;
             // Set fast open option
-            if(setsockopt(sockfd, IPPROTO_TCP, TCP_FASTOPEN,
-                          &optval, sizeof(optval)) != 0) {
+            if (setsockopt(sockfd, IPPROTO_TCP, TCP_FASTOPEN,
+                           &optval, sizeof(optval)) != 0) {
                 ERROR("setsockopt");
                 break;
             }

--- a/src/server.h
+++ b/src/server.h
@@ -32,7 +32,7 @@
 #include <ev.h>
 #endif
 
-#ifdef TCP_FASTOPEN_WINSOCK
+#ifdef __MINGW32__
 #include "winsock.h"
 #endif
 

--- a/src/server.h
+++ b/src/server.h
@@ -32,6 +32,10 @@
 #include <ev.h>
 #endif
 
+#ifdef TCP_FASTOPEN_WINSOCK
+#include "winsock.h"
+#endif
+
 #include "crypto.h"
 #include "jconf.h"
 #include "resolv.h"
@@ -104,6 +108,10 @@ typedef struct remote_ctx {
 
 typedef struct remote {
     int fd;
+#ifdef TCP_FASTOPEN_WINSOCK
+    OVERLAPPED olap;
+    int connect_ex_done;
+#endif
     buffer_t *buf;
     struct remote_ctx *recv_ctx;
     struct remote_ctx *send_ctx;

--- a/src/winsock.h
+++ b/src/winsock.h
@@ -78,10 +78,9 @@
 // Check if ConnectEx supported in header
 #ifdef WSAID_CONNECTEX
 // Hardcode TCP fast open option
-#ifdef TCP_FASTOPEN
-#undef TCP_FASTOPEN
-#endif
+#ifndef TCP_FASTOPEN
 #define TCP_FASTOPEN 15
+#endif
 // Enable TFO support
 #define TCP_FASTOPEN_WINSOCK 1
 #endif

--- a/src/winsock.h
+++ b/src/winsock.h
@@ -25,6 +25,7 @@
 
 #ifdef __MINGW32__
 
+// Target NT6
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -37,11 +38,13 @@
 #define _WIN32_WINNT 0x0600
 #endif
 
+// Winsock headers
 #include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <mswsock.h>
 
-// Override error number
+// Override POSIX error number
 #ifdef errno
 #undef errno
 #endif
@@ -56,6 +59,32 @@
 #undef CONNECT_IN_PROGRESS
 #endif
 #define CONNECT_IN_PROGRESS WSAEWOULDBLOCK
+
+#ifdef EOPNOTSUPP
+#undef EOPNOTSUPP
+#endif
+#define EOPNOTSUPP WSAEOPNOTSUPP
+
+#ifdef EPROTONOSUPPORT
+#undef EPROTONOSUPPORT
+#endif
+#define EPROTONOSUPPORT WSAEPROTONOSUPPORT
+
+#ifdef ENOPROTOOPT
+#undef ENOPROTOOPT
+#endif
+#define ENOPROTOOPT WSAENOPROTOOPT
+
+// Check if ConnectEx supported in header
+#ifdef WSAID_CONNECTEX
+// Hardcode TCP fast open option
+#ifdef TCP_FASTOPEN
+#undef TCP_FASTOPEN
+#endif
+#define TCP_FASTOPEN 15
+// Enable TFO support
+#define TCP_FASTOPEN_WINSOCK 1
+#endif
 
 // Override close function
 #define close(fd) closesocket(fd)
@@ -80,6 +109,10 @@ void ss_error(const char *s);
 int setnonblocking(SOCKET socket);
 void winsock_init(void);
 void winsock_cleanup(void);
+#ifdef TCP_FASTOPEN_WINSOCK
+LPFN_CONNECTEX winsock_getconnectex(void);
+int winsock_dummybind(SOCKET fd, struct sockaddr *sa);
+#endif
 
 #endif // __MINGW32__
 


### PR DESCRIPTION
As we have an efficient MinGW port at the moment, how about adding TCP Fast Open  (TFO) support on Windows?

Let me start the discussion here in this pull request. Please **do not merge it** until it is fully reviewed. This patch needs more tests.

### Build with Docker

To build this patch with Docker, you need to edit `docker/mingw/build.sh` and run `make` or `make.bat`:
1. Change `git checkout ${PROJ_REV}` into **`git checkout pr`**.
2. Add one line **before** `git checkout pr`: **`git fetch origin pull/1965/head:pr`**

### Background

TFO is **only** supported on Windows 10, **1607** or later version (the earliest supported OS version should be [Build 14393](https://github.com/shadowsocks/shadowsocks-windows/blob/53ec77901c91d7f273ca4b35ad54de45353103db/shadowsocks-csharp/Util/Util.cs#L280)). So this patch will not benefit any OS before Windows 10 (Windows 7, 8, 8.1 etc.).

### TFO Fallback in Windows

Thanks to @wongsyrone 's hint, on 1709 (build 16299) or later version of Windows 10, the system has a very aggressive TFO fallback mechanism and will completely disable TFO silently until next restart if fallback is hit. I recommend to run the following command (in PowerShell/Command Prompt, requires Administrator) and **reboot** before trying this patch:

```
netsh int tcp set global fastopen=enabled
netsh int tcp set global fastopenfallback=disabled
```
These two lines ensure TFO is enabled but the aggressive fallback is disabled. There is no need to do this before 1709, but there is no harm to do so.

### How does this patch work?

1. Call `setsockopt` to set `IPPROTO_TCP` option as `TCP_FASTOPEN` (equals 15).
2. Call the asynchronous function `ConnectEx` to connect to the remote server along with initial data. 

### More comments

`ConnectEx` is similar to `sendto` on Linux using `MSG_FASTOPEN` option. But it mostly returns FALSE and sets error number to `ERROR_IO_PENDING`. So how to get the result from `ConnectEx` (i.e. sent bytes) in a non-blocking way? This patch delays the check to `remote_send_cb` by using non-blocking version of `WSAGetOverlappedResult`. I am not quite sure if the flow here is correct. **Any comment on this?**

I have initially tested this patch on Windows 10 v1709 (16299.125). It *seems* to work for both client and server. ~~But I didn't capture the packets to confirm.~~ **Further tests and reports are welcome.**

### Some references

* MSDN: [Socket option](https://msdn.microsoft.com/en-us/library/windows/desktop/ms738596(v=vs.85).aspx), [ConnectEx](https://msdn.microsoft.com/en-us/library/windows/desktop/ms737606(v=vs.85).aspx)
* Discussions on shadowsocks-windows: [1045](https://github.com/shadowsocks/shadowsocks-windows/issues/1045), [1328](https://github.com/shadowsocks/shadowsocks-windows/pull/1328)
* .NET support of TFO: [CoreFX](https://github.com/dotnet/corefx/issues/16375), [blog.hjc.im](https://blog.hjc.im/dotnet-core-tcp-fast-open.html) (in Chinese)
* ConnectEx Example from [Stackoverflow](https://stackoverflow.com/questions/13598530/connectex-requires-the-socket-to-be-initially-bound-but-to-what) and [libevent](https://github.com/libevent/libevent/blob/92cc0b9c3db38088f79c5d1e432c429fbc366968/bufferevent_async.c#L614)
* NSPR (from Gecko engine of Firefox) [implementation](https://github.com/mozilla/gecko-dev/blob/1ab99b429543eb88fbf38bc17e0648cb62a080bd/nsprpub/pr/src/md/windows/w95sock.c#L406) and [related patch](https://github.com/mozilla/gecko-dev/commit/4a9976e5550afc20b96139580205514b99ed11db#diff-8fc11e337634fda139867da5d2b71ff6)