### PR TITLE
Simplify Docker build on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,16 +340,11 @@ brew install shadowsocks-libev
 ### Windows (MinGW)
 To build Windows native binaries, the recommended method is to use Docker:
 
+* On Windows: double-click `make.bat` in `docker\mingw`
 * On Unix-like system:
 
         cd shadowsocks-libev/docker/mingw
         make
-
-* On Windows (Command Prompt):
-
-        cd shadowsocks-libev\docker\mingw
-        docker build --force-rm -t ss --build-arg REBUILD=%RANDOM% .
-        docker run --rm --entrypoint cat ss /bin.tgz > ss-win.tgz
 
 A tarball with 32-bit and 64-bit binaries will be generated in the same directory.
 

--- a/docker/mingw/make.bat
+++ b/docker/mingw/make.bat
@@ -1,0 +1,11 @@
+@echo off
+pushd %~dp0
+set "REPO=shadowsocks"
+set "REV=master"
+set "IMAGE=ss-build-mingw"
+set "DIST=ss-libev-win-dist.tar.gz"
+docker build --force-rm -t %IMAGE% ^
+      --build-arg REV=%REV% --build-arg REPO=%REPO% ^
+      --build-arg REBUILD=%RANDOM% .
+docker run --rm --entrypoint cat %IMAGE% /bin.tgz > %DIST%
+pause


### PR DESCRIPTION
Add a Batch file `make.bat` in `docker/mingw` for Windows Docker users. Now one can simply double-click `make.bat` to build MinGW ports on Windows.