### PR TITLE
Update libcork and Docker script for MinGW

### DIFF
--- a/docker/mingw/Dockerfile
+++ b/docker/mingw/Dockerfile
@@ -38,5 +38,6 @@ RUN /bin/bash -c "source /deps.sh && dk_deps"
 ADD build.sh /
 
 ARG REBUILD=0
+ARG PLUGIN=true
 
 RUN /bin/bash -c "source /build.sh && dk_build && dk_package"

--- a/docker/mingw/build.sh
+++ b/docker/mingw/build.sh
@@ -85,8 +85,8 @@ dk_package() {
         cp ${DIST}/x86_64/bin/ss-${bin}.exe ss-${bin}-x64.exe
     done
     for bin in local server; do
-        cp ${DIST}/i686/bin/obfs-${bin}.exe obfs-${bin}-x86.exe
-        cp ${DIST}/x86_64/bin/obfs-${bin}.exe obfs-${bin}-x64.exe
+        cp ${DIST}/i686/bin/obfs-${bin}.exe obfs-${bin}-x86.exe || true
+        cp ${DIST}/x86_64/bin/obfs-${bin}.exe obfs-${bin}-x64.exe || true
     done
     pushd "$SRC/proj"
     GIT_REV="$(git rev-parse --short HEAD)"


### PR DESCRIPTION
Update libcork submodule to support the plugin feature of MinGW port (see #1978). Also fixed a minor bug in Docker build script when plugin build is disabled.