### PR TITLE
MinGW: fix socket closing in wrong place

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -110,12 +110,14 @@ static struct ev_signal sigterm_watcher;
 static struct ev_signal sigchld_watcher;
 static struct ev_signal sigusr1_watcher;
 #else
+#ifndef LIB_ONLY
 static struct plugin_watcher_t {
     ev_io io;
     SOCKET fd;
     uint16_t port;
     int valid;
 } plugin_watcher;
+#endif
 #endif
 
 #ifdef HAVE_SETRLIMIT
@@ -1323,7 +1325,9 @@ signal_cb(EV_P_ ev_signal *w, int revents)
             ev_signal_stop(EV_DEFAULT, &sigchld_watcher);
             ev_signal_stop(EV_DEFAULT, &sigusr1_watcher);
 #else
+#ifndef LIB_ONLY
             ev_io_stop(EV_DEFAULT, &plugin_watcher.io);
+#endif
 #endif
             keep_resolving = 0;
             ev_unloop(EV_A_ EVUNLOOP_ALL);
@@ -1890,6 +1894,10 @@ main(int argc, char **argv)
     }
 
 #ifdef __MINGW32__
+    if (plugin_watcher.valid) {
+        closesocket(plugin_watcher.fd);
+    }
+
     winsock_cleanup();
 #endif
 
@@ -2039,10 +2047,6 @@ _start_ss_local_server(profile_t profile, ss_local_callback callback, void *udat
     }
 
 #ifdef __MINGW32__
-    if (plugin_watcher.valid) {
-        closesocket(plugin_watcher.fd);
-    }
-
     winsock_cleanup();
 #endif
 


### PR DESCRIPTION
Fix an issue that closes the plugin watcher socket in library only mode.