### PR TITLE
MinGW: Support colored text in Windows console

### DIFF
--- a/docker/mingw/build.sh
+++ b/docker/mingw/build.sh
@@ -31,11 +31,15 @@ build_proj() {
     dep=${PREFIX}/$arch
 
     cd "$SRC"
-    git clone ${PROJ_URL} proj
-    cd proj
-    git checkout ${PROJ_REV}
-    git submodule update --init
-    ./autogen.sh
+    if ! [ -d proj ]; then
+        git clone ${PROJ_URL} proj
+        cd proj
+        git checkout ${PROJ_REV}
+        git submodule update --init
+        ./autogen.sh
+    else
+        cd proj
+    fi
     ./configure --host=${host} --prefix=${prefix} \
       --disable-documentation \
       --with-ev="$dep" \
@@ -55,11 +59,15 @@ build_proj() {
     PLUGIN_REV=master
 
     cd "$SRC"
-    git clone ${PLUGIN_URL} plugin
-    cd plugin
-    git checkout ${PLUGIN_REV}
-    git submodule update --init
-    ./autogen.sh
+    if ! [ -d plugin ]; then
+        git clone ${PLUGIN_URL} plugin
+        cd plugin
+        git checkout ${PLUGIN_REV}
+        git submodule update --init
+        ./autogen.sh
+    else
+        cd plugin
+    fi
     ./configure --host=${host} --prefix=${prefix} \
       --disable-documentation \
       --with-ev="$dep"

--- a/docker/mingw/deps.sh
+++ b/docker/mingw/deps.sh
@@ -60,8 +60,7 @@ build_deps() {
     cd "$SRC/$PCRE_SRC"
     ./configure $args \
       --enable-jit --disable-cpp \
-      --enable-unicode-properties \
-      --enable-pcre16 --enable-pcre32
+      --enable-unicode-properties
     make clean
     make install
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -98,8 +98,10 @@ extern FILE *logfile;
         time_t now = time(NULL);                             \
         char timestr[20];                                    \
         strftime(timestr, 20, TIME_FORMAT, localtime(&now)); \
-        fprintf(stdout, " %s INFO: " format "\n", timestr,   \
-                ## __VA_ARGS__);                             \
+        ss_color_info();                                     \
+        fprintf(stdout, " %s INFO: ", timestr);              \
+        ss_color_reset();                                    \
+        fprintf(stdout, format "\n", ## __VA_ARGS__);        \
     }                                                        \
     while (0)
 
@@ -108,8 +110,10 @@ extern FILE *logfile;
         time_t now = time(NULL);                              \
         char timestr[20];                                     \
         strftime(timestr, 20, TIME_FORMAT, localtime(&now));  \
-        fprintf(stdout, " %s ERROR: " format "\n", timestr,   \
-                ## __VA_ARGS__);                              \
+        ss_color_error();                                     \
+        fprintf(stdout, " %s ERROR: ", timestr);              \
+        ss_color_reset();                                     \
+        fprintf(stdout, format "\n", ## __VA_ARGS__);         \
     }                                                         \
     while (0)
 
@@ -196,7 +200,12 @@ extern int use_syslog;
 #undef ERROR
 #endif
 #define ERROR(s) ss_error(s)
-void ss_error(const char *s); // Implemented in winsock.c
+
+// Implemented in winsock.c
+void ss_error(const char *s);
+void ss_color_info(void);
+void ss_color_error(void);
+void ss_color_reset(void);
 #else
 void ERROR(const char *s);
 #endif

--- a/src/winsock.c
+++ b/src/winsock.c
@@ -133,11 +133,12 @@ set_concolor(WORD color, BOOL reset)
     static HANDLE console = NULL;
     if (console == NULL) {
         console = GetStdHandle(STD_OUTPUT_HANDLE);
-        if (console == NULL ||
-            console == INVALID_HANDLE_VALUE) {
-            console = NULL;
-            return FALSE;
-        }
+    }
+    if (console == NULL ||
+        console == INVALID_HANDLE_VALUE) {
+        // If no console is available, we will not try again
+        console = INVALID_HANDLE_VALUE;
+        return FALSE;
     }
     WORD attr;
     if (!get_conattr(console, &attr)) {

--- a/src/winsock.c
+++ b/src/winsock.c
@@ -109,6 +109,20 @@ ss_error(const char *s)
     }
 }
 
+char *
+ss_gai_strerror(int ecode)
+{
+    static TCHAR buff[GAI_STRERROR_BUFFER_SIZE + 1];
+    FormatMessage(
+        FORMAT_MESSAGE_FROM_SYSTEM |
+        FORMAT_MESSAGE_IGNORE_INSERTS |
+        FORMAT_MESSAGE_MAX_WIDTH_MASK,
+        NULL, ecode,
+        MAKELANGID(LANG_NEUTRAL,SUBLANG_DEFAULT),
+        (LPTSTR)buff, GAI_STRERROR_BUFFER_SIZE, NULL);
+    return (char *)buff;
+}
+
 static BOOL
 get_conattr(HANDLE console, WORD *out_attr)
 {

--- a/src/winsock.h
+++ b/src/winsock.h
@@ -98,6 +98,12 @@
 #endif
 #define ERROR(s) ss_error(s)
 
+#ifdef gai_strerror
+#undef gai_strerror
+#endif
+#define gai_strerror(e) ss_gai_strerror(e)
+char *ss_gai_strerror(int ecode);
+
 // Missing Unix functions
 #define sleep(x) Sleep((x) * 1000)
 #define bzero(s,n) memset(s,0,n)


### PR DESCRIPTION
Now we can also have nice colored text in Windows console just like other platforms. This patch also fixes some minor things, including docker script and error message handling.