### PR TITLE
Ignore SIGCHLD for library usage

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -1980,9 +1980,7 @@ _start_ss_local_server(profile_t profile, ss_local_callback callback, void *udat
     ev_signal_start(EV_DEFAULT, &sigterm_watcher);
 #ifndef __MINGW32__
     ev_signal_init(&sigusr1_watcher, signal_cb, SIGUSR1);
-    ev_signal_init(&sigchld_watcher, signal_cb, SIGCHLD);
     ev_signal_start(EV_DEFAULT, &sigusr1_watcher);
-    ev_signal_start(EV_DEFAULT, &sigchld_watcher);
 #endif
 
     // Setup keys


### PR DESCRIPTION
### Problem
Steps to reproduce: (1) Run `start_ss_local_server` in a background thread. (2) Start an arbitary child process in the main process. When the child process terminates, shadowsocks will terminate unexpectedly, printing log `plugin service exit unexpectedly`.

### Cause
Shadowsocks listens for `SIGCHLD` of its plugin processes, if shadowsocks is running in a thread instead of a separate process, `SIGCHLD` sent for other receivers will be processed by shadowsocks, and may cause the problem above.

### Fix
Since plugin is not supported in library usage (according to `profile_t` in `shadowsocks.h`), I think we can simply ignore the signal.