### PR TITLE
Create srpm and rpm targets to the Autotools build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build/
 .deps/
 /Makefile
 src/Makefile
+rpm/Makefile
 libev/Makefile
 libudns/Makefile
 libcork/Makefile

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 if USE_SYSTEM_SHARED_LIB
-SUBDIRS = src
+SUBDIRS = src rpm
 else
-SUBDIRS = libcork libipset libbloom src
+SUBDIRS = libcork libipset libbloom src rpm
 endif
 
 if ENABLE_DOCUMENTATION

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_USE_SYSTEM_EXTENSIONS
 
 AM_INIT_AUTOMAKE([subdir-objects foreign -Wno-gnu -Werror])
+AM_EXTRA_RECURSIVE_TARGETS([rpm srpm])
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_MAINTAINER_MODE
@@ -239,7 +240,8 @@ AC_CHECK_LIB([ev], [ev_loop_destroy], [LIBS="-lev $LIBS"], [AC_MSG_ERROR([Couldn
 AC_CONFIG_FILES([shadowsocks-libev.pc
                  Makefile
                  doc/Makefile
-                 src/Makefile])
+                 src/Makefile
+                 rpm/Makefile])
 
 AM_COND_IF([USE_SYSTEM_SHARED_LIB],
 		   [AC_DEFINE([USE_SYSTEM_SHARED_LIB], [1], [Define if use system shared lib.])],

--- a/rpm/Makefile.am
+++ b/rpm/Makefile.am
@@ -1,0 +1,8 @@
+clean-local:
+	-rm -rf BUILD BUILDROOT RPMS SRPMS SPECS/*.spec SOURCES/*.tar SOURCES/*.gz
+srpm:
+	-./genrpm.sh -S
+rpm:
+	-./genrpm.sh
+
+.PHONY: srpm rpm

--- a/rpm/genrpm.sh
+++ b/rpm/genrpm.sh
@@ -4,6 +4,9 @@ set -e
 SELF=$(readlink -f -- "$0")
 HERE=$(dirname -- "$SELF")
 
+RPMBUILD=rpmbuild
+RPMBUILD_OPTS=
+
 show_help()
 {
     echo -e "`basename $0` [OPTION...]"
@@ -11,11 +14,13 @@ show_help()
     echo -e "Options:"
     echo -e "  -h    show this help."
     echo -e "  -s    use system shared libraries"
+    echo -e "  -S    build SRPMs only"
 }
 
 OPT_USE_SYSTEM_LIB=0
+OPT_SRPMS_ONLY=0
 
-while getopts "hs" opt
+while getopts "hsS" opt
 do
     case ${opt} in
         h)
@@ -26,6 +31,9 @@ do
 		s)
             OPT_USE_SYSTEM_LIB=1
 			;;
+        S)
+            OPT_SRPMS_ONLY=1
+            ;;
         *)
 			show_help
             exit 1
@@ -82,6 +90,11 @@ sed -e "s/^\(Version:\).*$/\1       ${TARGET_VERSION}/" \
     "${TARGET_SPEC_PATH}".in > "${TARGET_SPEC_PATH}"
 
 # build rpms
-rpmbuild -ba "$TARGET_SPEC_PATH" \
+if [ "$OPT_SRPMS_ONLY" -ne 0 ]; then
+    RPMBUILD_OPTS+=' -bs'
+else
+    RPMBUILD_OPTS+=' -ba'
+fi
+"$RPMBUILD" $RPMBUILD_OPTS "$TARGET_SPEC_PATH" \
          --define "%_topdir $HERE" \
          --define "%use_system_lib $OPT_USE_SYSTEM_LIB"


### PR DESCRIPTION
The new `srpm` target can be handled by Fedora Copr for
automated builds. A `rpm` target is also added for alignment.