### PR TITLE
Change README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,13 +263,13 @@ For some of the distributions, you might install build dependencies like this:
 ```bash
 # Installation of basic build dependencies
 ## Debian / Ubuntu
-sudo apt-get install --no-install-recommends gettext build-essential autoconf libtool libpcre3-dev asciidoc xmlto libev-dev libc-ares-dev automake libmbedtls-dev libsodium-dev
+sudo apt-get install --no-install-recommends gettext build-essential autoconf libtool libpcre3-dev asciidoc xmlto libev-dev libc-ares-dev automake libmbedtls-dev
 ## CentOS / Fedora / RHEL
 sudo yum install gettext gcc autoconf libtool automake make asciidoc xmlto c-ares-devel libev-devel
 ## Arch
 sudo pacman -S gettext gcc autoconf libtool automake make asciidoc xmlto c-ares libev
 
-# Installation of Libsodium
+# Installation of Libsodium #If you're a Debian 9 user,you should do this rather than install libsodium-dev.
 export LIBSODIUM_VER=1.0.13
 wget https://download.libsodium.org/libsodium/releases/libsodium-$LIBSODIUM_VER.tar.gz
 tar xvf libsodium-$LIBSODIUM_VER.tar.gz

--- a/README.md
+++ b/README.md
@@ -269,7 +269,8 @@ sudo yum install gettext gcc autoconf libtool automake make asciidoc xmlto c-are
 ## Arch
 sudo pacman -S gettext gcc autoconf libtool automake make asciidoc xmlto c-ares libev
 
-# Installation of Libsodium #If you're a Debian 9 user,you should do this rather than install libsodium-dev.
+# Installation of Libsodium 
+#If you're a Debian 9 user,you should do this rather than install libsodium-dev.
 export LIBSODIUM_VER=1.0.13
 wget https://download.libsodium.org/libsodium/releases/libsodium-$LIBSODIUM_VER.tar.gz
 tar xvf libsodium-$LIBSODIUM_VER.tar.gz


### PR DESCRIPTION
The version of libsodium-dev installed from Debian 9 official repository is 1.0.11-2 500,but the program need 1.0.12 or later.