### PR TITLE
update image value.

### DIFF
--- a/docker/alpine/docker-compose.yml
+++ b/docker/alpine/docker-compose.yml
@@ -1,5 +1,5 @@
 shadowsocks:
-  image: shadowsocks-libev
+  image: shadowsocks/shadowsocks-libev
   ports:
     - "8388:8388/tcp"
     - "8388:8388/udp"


### PR DESCRIPTION
Current setting will cause following error: `ERROR: pull access denied for shadowsocks-libev, repository does not exist or may require 'docker login'`, this update fixes this.