### PR TITLE
Docker: speed up MinGW build by parallel make

### DIFF
--- a/docker/mingw/build.sh
+++ b/docker/mingw/build.sh
@@ -29,6 +29,7 @@ build_proj() {
     host=$arch-w64-mingw32
     prefix=${DIST}/$arch
     dep=${PREFIX}/$arch
+    cpu="$(nproc --all)"
 
     cd "$SRC"
     if ! [ -d proj ]; then
@@ -49,7 +50,7 @@ build_proj() {
       --with-cares="$dep" \
       CFLAGS="-DCARES_STATICLIB -DPCRE_STATIC"
     make clean
-    make LDFLAGS="-all-static -L${dep}/lib"
+    make -j$cpu LDFLAGS="-all-static -L${dep}/lib"
     make install-strip
 
     # Reference SIP003 plugin (Experimental)
@@ -72,7 +73,7 @@ build_proj() {
       --disable-documentation \
       --with-ev="$dep"
     make clean
-    make LDFLAGS="-all-static -L${dep}/lib"
+    make -j$cpu LDFLAGS="-all-static -L${dep}/lib"
     make install-strip
 }
 

--- a/docker/mingw/deps.sh
+++ b/docker/mingw/deps.sh
@@ -29,17 +29,18 @@ build_deps() {
     host=$arch-w64-mingw32
     prefix=${PREFIX}/$arch
     args="--host=${host} --prefix=${prefix} --disable-shared --enable-static"
+    cpu="$(nproc --all)"
 
     # libev
     cd "$SRC/$LIBEV_SRC"
     ./configure $args
     make clean
-    make install
+    make -j$cpu install
 
     # mbedtls
     cd "$SRC/$MBEDTLS_SRC"
     make clean
-    make lib WINDOWS=1 CC="${host}-gcc" AR="${host}-ar"
+    make -j$cpu lib WINDOWS=1 CC="${host}-gcc" AR="${host}-ar"
     ## "make install" command from mbedtls
     DESTDIR="${prefix}"
     mkdir -p "${DESTDIR}"/include/mbedtls
@@ -54,21 +55,20 @@ build_deps() {
     cd "$SRC/$SODIUM_SRC"
     ./configure $args
     make clean
-    make install
+    make -j$cpu install
 
     # pcre
     cd "$SRC/$PCRE_SRC"
-    ./configure $args \
-      --enable-jit --disable-cpp \
+    ./configure $args --disable-cpp \
       --enable-unicode-properties
     make clean
-    make install
+    make -j$cpu install
 
     # c-ares
     cd "$SRC/$CARES_SRC"
     ./configure $args
     make clean
-    make install
+    make -j$cpu install
 }
 
 dk_deps() {


### PR DESCRIPTION
We can further speed up MinGW build by `make -j$(nproc)` to utilize all cores.