### PR TITLE
Docker: Support for IPv6 host, set default encryption method to GCM.

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -6,9 +6,10 @@ FROM alpine
 LABEL maintainer="kev <noreply@datageek.info>, Sah <contact@leesah.name>"
 
 ENV SERVER_ADDR 0.0.0.0
+ENV SERVER_ADDR_IPV6 ::0
 ENV SERVER_PORT 8388
 ENV PASSWORD=
-ENV METHOD      aes-256-cfb
+ENV METHOD      aes-256-gcm
 ENV TIMEOUT     300
 ENV DNS_ADDRS    8.8.8.8,8.8.4.4
 ENV ARGS=
@@ -45,6 +46,7 @@ USER nobody
 
 CMD exec ss-server \
       -s $SERVER_ADDR \
+      -s $SERVER_ADDR_IPV6 \
       -p $SERVER_PORT \
       -k ${PASSWORD:-$(hostname)} \
       -m $METHOD \

--- a/docker/alpine/README.md
+++ b/docker/alpine/README.md
@@ -33,7 +33,7 @@ $ docker run -p 8388:8388 -p 8388:8388/udp -d --restart always shadowsocks/shado
 ```
 This starts a container of the latest release with all the default settings, which is equivalent to
 ```bash
-$ ss-server -s 0.0.0.0 -p 8388 -k "$(hostname)" -m aes-256-cfb -t 300 --fast-open -d "8.8.8.8,8.8.4.4" -u
+$ ss-server -s 0.0.0.0 -p 8388 -k "$(hostname)" -m aes-256-gcm -t 300 --fast-open -d "8.8.8.8,8.8.4.4" -u
 ```
 > **Note**: It's the hostname in the container that is used as the password, not that of the host.
 
@@ -59,7 +59,8 @@ $ docker run -e PASSWORD=9MLSpPmNt -p 8388:8388 -p 8388:8388/udp -d --restart al
 ### With other customizations
 Besides `PASSWORD`, the image also defines the following environment variables that you can customize:
 * `SERVER_ADDR`: the IP/domain to bind to, defaults to `0.0.0.0`
-* `METHOD`: encryption method to use, defaults to `aes-256-cfb`
+* `SERVER_ADDR_IPV6`: the IPv6 address to bind to, defaults to `::0`
+* `METHOD`: encryption method to use, defaults to `aes-256-gcm`
 * `TIMEOUT`: defaults to `300`
 * `DNS_ADDRS`: DNS servers to redirect NS lookup requests to, defaults to `8.8.8.8,8.8.4.4`
 
@@ -81,7 +82,7 @@ shadowsocks:
   ports:
     - "8388:8388"
   environment:
-    - METHOD=aes-256-cfb
+    - METHOD=aes-256-gcm
     - PASSWORD=9MLSpPmNt
   restart: always
 ```
@@ -109,7 +110,7 @@ Don't forget to share internet with your friends.
     "local_port": 1080,
     "password": "9MLSpPmNt",
     "timeout": 600,
-    "method": "aes-256-cfb"
+    "method": "aes-256-gcm"
 }
 ```
 

--- a/docker/alpine/docker-compose.yml
+++ b/docker/alpine/docker-compose.yml
@@ -4,6 +4,6 @@ shadowsocks:
     - "8388:8388/tcp"
     - "8388:8388/udp"
   environment:
-    - METHOD=aes-256-cfb
+    - METHOD=aes-256-gcm
     - PASSWORD=9MLSpPmNt
   restart: always


### PR DESCRIPTION
I have refined the Dockerfile to use AEAD by default and support listen on IPv6.

The old PR was closed because it was mistakenly made from my master branch.