### PR TITLE
Use libsodium for `aes-256-gcm` when available.

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -36,7 +36,10 @@
 #include <inttypes.h>
 #endif
 
-/* Definations for mbedTLS */
+/* Definitions for libsodium */
+#include <sodium.h>
+typedef crypto_aead_aes256gcm_state aes256gcm_ctx;
+/* Definitions for mbedTLS */
 #include <mbedtls/cipher.h>
 #include <mbedtls/md.h>
 typedef mbedtls_cipher_info_t cipher_kt_t;
@@ -105,6 +108,7 @@ typedef struct {
     uint32_t init;
     uint64_t counter;
     cipher_evp_t *evp;
+    aes256gcm_ctx *aes256gcm_ctx;
     cipher_t *cipher;
     buffer_t *chunk;
     uint8_t salt[MAX_KEY_LENGTH];


### PR DESCRIPTION
There is a known issue that mbedTLS does not implement AES-NI correctly.
https://github.com/shadowsocks/shadowsocks-libev/issues/2147

However the libsodium have support for AES-NI (although only for 256bit AES/GCM).

This PR makes the method `aes-256-gcm` use libsodium's implementation when it is available.

To: @madeye please kindly review my PR and provide your insights.

To: @xqdoo00o could you help me benchmark the performance on your machine along with the Go version?