### PR TITLE
Add `gcc` back to Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: required
 language: c
 dist : trusty
-compiler: clang
+compiler:
+    - clang
+    - gcc
 os:
     - linux
     - osx


### PR DESCRIPTION
We should run CI on all supported platform to avoid regression happened with my previous PR.
I am sorry for the compilation error on older platform.