### PR TITLE
Add `CAP_NET_BIND_SERVICE` to `shadowsocks-libev.service`

### DIFF
--- a/debian/shadowsocks-libev.service
+++ b/debian/shadowsocks-libev.service
@@ -15,6 +15,7 @@ After=network.target
 
 [Service]
 Type=simple
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 EnvironmentFile=/etc/default/shadowsocks-libev
 User=nobody
 Group=nogroup


### PR DESCRIPTION
It ensures process have permission to bind to port <=1000.
Other systemd config files already have it except this one.