### PR TITLE
Refine passing plugin args

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -101,7 +101,7 @@ static crypto_t *crypto;
 static int acl       = 0;
 static int mode      = TCP_ONLY;
 static int ipv6first = 0;
-static int fast_open = 0;
+       int fast_open = 0;
 static int no_delay  = 0;
 static int udp_fd    = 0;
 static int ret_val   = 0;

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -109,10 +109,13 @@ start_ss_plugin(const char *plugin,
     if (plugin_opts != NULL)
         cork_env_add(env, "SS_PLUGIN_OPTIONS", plugin_opts);
 
+    exec = cork_exec_new(plugin);
+    cork_exec_add_param(exec, plugin);  // argv[0]
+    extern int fast_open;
+    if (fast_open) cork_exec_add_param(exec, "--fast-open");
 #ifdef __ANDROID__
-    exec = cork_exec_new_with_params("sh", "-c", plugin, NULL);
-#else
-    exec = cork_exec_new_with_params(plugin, NULL);
+    extern int vpn;
+    if (vpn) cork_exec_add_param(exec, "-V");
 #endif
 
     cork_exec_set_env(exec, env);

--- a/src/redir.c
+++ b/src/redir.c
@@ -93,7 +93,7 @@ static int mode      = TCP_ONLY;
 #ifdef HAVE_SETRLIMIT
 static int nofile = 0;
 #endif
-static int fast_open = 0;
+       int fast_open = 0;
 static int no_delay  = 0;
 static int ret_val   = 0;
 

--- a/src/server.c
+++ b/src/server.c
@@ -120,7 +120,7 @@ static crypto_t *crypto;
 static int acl       = 0;
 static int mode      = TCP_ONLY;
 static int ipv6first = 0;
-static int fast_open = 0;
+       int fast_open = 0;
 static int no_delay  = 0;
 static int ret_val   = 0;
 

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -95,7 +95,7 @@ static int mode      = TCP_ONLY;
 static int nofile = 0;
 #endif
 static int no_delay  = 0;
-static int fast_open = 0;
+       int fast_open = 0;
 static int ret_val   = 0;
 
 static struct ev_signal sigint_watcher;


### PR DESCRIPTION
Refine 68f885c271bf1c2fbe98cfcc98e75b48cde65045. Somehow I postponed this change for 8 months. Good job me!

This fix the cases when there is a space in plugin path, for whatever reason.

Also I think I prefer this to putting them in `SS_PLUGIN_OPTIONS`.