### PR TITLE
configure.ac: fix static build with netfilter_conntrack

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -256,7 +256,7 @@ if test x"$enable_connmarktos" = "xyes" ; then
 	        if test x"$enable_connmarktos" = "xyes"; then
 	            AC_MSG_ERROR([--enable-connmarktos specified but libnetfilter-conntrack library not found])
 	        fi
-	        with_netfilter_conntrack=no])
+	        with_netfilter_conntrack=no], [-lnfnetlink])
 	    AC_CHECK_HEADERS([libnetfilter_conntrack/libnetfilter_conntrack.h \
 	        libnetfilter_conntrack/libnetfilter_conntrack_tcp.h],,[
 	        if test x"$enable_connmarktos" = "xyes"; then


### PR DESCRIPTION
Fixes:
 - http://autobuild.buildroot.org/results/22a28e8fd8182e1c908541dbc5b0ee087c3803e6

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>