### PR TITLE
Switch user before starting plugin server

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -1927,6 +1927,17 @@ main(int argc, char **argv)
     ev_signal_start(EV_DEFAULT, &sigchld_watcher);
 #endif
 
+#ifndef __MINGW32__
+    // setuid
+    if (user != NULL && !run_as(user)) {
+        FATAL("failed to switch user");
+    }
+
+    if (geteuid() == 0) {
+        LOGI("running from root user");
+    }
+#endif
+
     // setup keys
     LOGI("initializing ciphers... %s", method);
     crypto = crypto_init(password, key, method);
@@ -2085,17 +2096,6 @@ main(int argc, char **argv)
 
     ev_timer_init(&block_list_watcher, block_list_clear_cb, UPDATE_INTERVAL, UPDATE_INTERVAL);
     ev_timer_start(EV_DEFAULT, &block_list_watcher);
-
-#ifndef __MINGW32__
-    // setuid
-    if (user != NULL && !run_as(user)) {
-        FATAL("failed to switch user");
-    }
-
-    if (geteuid() == 0) {
-        LOGI("running from root user");
-    }
-#endif
 
     // init block list
     init_block_list();


### PR DESCRIPTION
This commit makes plugin server running as the user given by `-a` argument.

It's useful for [v2ray-plugin](https://github.com/shadowsocks/v2ray-plugin) when certificate and/or key file for TLS method only can be accessed by specified user.

```
user@localhost:~$ ll /path/to/host.*
-rw------- 1 ss-libev ss-libev 1143 Jan 29 09:33 /path/to/host.cer
-rw------- 1 ss-libev ss-libev  241 Jan 29 09:33 /path/to/host.key
user@localhost:~$ sudo -b ss-server -p 4433 -k XXX -a ss-libev --plugin v2ray-plugin --plugin-opts "server;tls;cert=/path/to/host.cer;key=/path/to/host.key"
 2019-02-03 19:39:24 INFO: plugin "v2ray-plugin" enabled
 2019-02-03 19:39:24 INFO: initializing ciphers... chacha20-ietf-poly1305
 2019-02-03 19:39:24 INFO: tcp server listening at 127.0.0.1:37429
2019/02/03 19:39:24 V2Ray 4.13 (Po) Custom
2019/02/03 19:39:24 A unified platform for anti-censorship.
2019/02/03 19:39:24 [Warning] v2ray.com/core: V2Ray 4.13 started

user@localhost:~$ ps -v --user ss-libev
15486 pts/0    S      0:00      0   176 33187  3588  0.3 ss-server -p 4433 -k XXX -a ss-libev --plugin v2ray-plugin --plugin-opts server;tls;cert=/path/to/host.cer;key=/path/to/host.key
15487 pts/0    Sl     0:00      0  3245 108850 13800  1.3 v2ray-plugin
```