### PR TITLE
fix cmake build on macOS

### DIFF
--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -18,6 +18,9 @@ include(CheckCSourceCompiles)
 set(CONNECT_IN_PROGRESS "EINPROGRESS")
 set(CONNECT_IN_PROGRESS "EINPROGRESS" CACHE STRING "")
 
+if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(CMAKE_REQUIRED_INCLUDES "/usr/local/include" "/usr/include")
+endif ()
 
 check_include_files(dlfcn.h HAVE_DLFCN_H)
 check_include_files(ev.h HAVE_EV_H)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,17 @@ set(SS_REDIR_SOURCE
         ${SS_PLUGIN_SOURCE}
         )
 
+if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+find_path(LIBSODIUM_INCLUDE_DIR sodium.h
+        PATHS
+        $ENV{LIBSODIUM_INCLUDE_DIR}
+        $ENV{LIBSODIUM_DIR}/include
+        /usr/local/libsodium/include
+        /opt/libsodium/include
+        /usr/local/include
+)
+include_directories(${LIBSODIUM_INCLUDE_DIR})
+endif ()
 
 if (WITH_STATIC)
 find_library(LIBSODIUM libsodium.a)


### PR DESCRIPTION
To build shadowsocks-libev on macOS by cmake:

1. need to set CMAKE_REQUIRED_INCLUDES to let check_include_files() find pcre
2. need to add sodium head file path to include directories

Assume both pcre and libsodium are installed by Homebrew.