### PR TITLE
cmake: keep execute permission of files in bin directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -239,6 +239,7 @@ target_link_libraries(shadowsocks-libev-shared ${DEPS_SHARED})
 # Misc
 # Recommend to install shared by default
 install(DIRECTORY ${RUNTIME_SHARED_OUTPUT_DIRECTORY}/
+        USE_SOURCE_PERMISSIONS
         DESTINATION bin)
 
 if (WITH_STATIC)


### PR DESCRIPTION
Since files in bin are binary executables, they shoud be installed with execute permission.

Before:

<img width="756" alt="2019-03-06 11 44 18" src="https://user-images.githubusercontent.com/261698/53854909-56b20700-4006-11e9-9744-098ab442056f.png">

After:

<img width="734" alt="2019-03-06 11 45 31" src="https://user-images.githubusercontent.com/261698/53854917-5f0a4200-4006-11e9-89db-dd9b4bf8eb8f.png">
