### PR TITLE
cmake: fix for system shared libs building, version string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(PROJECT_VERSION "3.2.5")
 set(PROJECT_DESC "a lightweight secured socks5 proxy")
 set(PROJECT_URL "https://shadowsocks.org")
 set(PROJECT_ISSUES_URL "https://github.com/shadowsocks/shadowsocks-libev")
-project(${PROJECT_NAME})
+project(${PROJECT_NAME} VERSION ${PROJECT_VERSION})
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,11 @@ option(WITH_EMBEDDED_SRC "build with embedded libcork, libipset, and libbloom so
 # Will set GIT_EXECUTABLE and GIT_FOUND
 # find_package(Git)
 
+# When choose to not use embedded libcork, libipset and libboom, use libs shipped by system
+if (NOT WITH_EMBEDDED_SRC)
+    set(USE_SYSTEM_SHARED_LIB TRUE)
+endif ()
+
 # Run platform tests
 include(${CMAKE_SOURCE_DIR}/cmake/configure.cmake)
 configure_file(${CMAKE_SOURCE_DIR}/cmake/config.h.cmake ${CMAKE_BINARY_DIR}/src/config.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ configure_file(
 )
 install(FILES
         ${CMAKE_BINARY_DIR}/pkgconfig/shadowsocks-libev.pc
-        DESTINATION pkgconfig
+        DESTINATION lib/pkgconfig
         )
 
 if (WITH_EMBEDDED_SRC)


### PR DESCRIPTION
1. change pkgconfig file installation path
2. When choose to not use embedded libcork, libipset and libboom, pass this flag to cmake/config.h.cmake, and let #cmakedefine take effect
3. fix empty version string output when building by cmake

So now many os distributions (e.g. archlinux's PKGBUILD) can choose to build packages by this:
```bash
cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DWITH_STATIC=OFF -DWITH_EMBEDDED_SRC=OFF
make DESTDIR=/tmp/aaaa install
```
