### PR TITLE
fix typo; change installation path of man and doc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ option(WITH_EMBEDDED_SRC "build with embedded libcork, libipset, and libbloom so
 # Will set GIT_EXECUTABLE and GIT_FOUND
 # find_package(Git)
 
-# When choose to not use embedded libcork, libipset and libboom, use libs shipped by system
+# When choose to not use embedded libcork, libipset and libbloom, use libs shipped by system
 if (NOT WITH_EMBEDDED_SRC)
     set(USE_SYSTEM_SHARED_LIB TRUE)
 endif ()

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -69,13 +69,19 @@ if (NOT WITH_DOC_MAN)
     set_target_properties(doc-man PROPERTIES EXCLUDE_FROM_ALL TRUE)
 else ()
     install(DIRECTORY ${CMAKE_BINARY_DIR}/man/
-            DESTINATION man)
+            DESTINATION share/man/man1
+            FILES_MATCHING PATTERN "*.1"
+            )
+    install(DIRECTORY ${CMAKE_BINARY_DIR}/man/
+            DESTINATION share/man/man8
+            FILES_MATCHING PATTERN "*.8"
+            )
 endif ()
 if (NOT WITH_DOC_HTML)
     set_target_properties(doc-html PROPERTIES EXCLUDE_FROM_ALL TRUE)
 else ()
     install(DIRECTORY ${CMAKE_BINARY_DIR}/html/
-            DESTINATION doc/html)
+            DESTINATION share/doc/${PROJECT_NAME})
 endif ()
 
 # This is required for custom command


### PR DESCRIPTION
1. fix a typo in comment of last pr
2. change man and doc installation path to be compliant with os distribution standard

Now:
<img width="666" alt="屏幕快照 2019-03-11 下午2 53 18" src="https://user-images.githubusercontent.com/261698/54105748-f14b8500-440e-11e9-98e5-15d8f8747a40.png">
