### PR TITLE
cmake: change to absolute path to avoid command running every time

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -23,6 +23,7 @@ if (EXISTS ${XMLTO_CATALOG_DIR_MACOS})
 endif ()
 
 set(CMAKE_MANPAGE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/man)
+set(CMAKE_HTML_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/html)
 
 set(DOC_DIR ${CMAKE_SOURCE_DIR}/doc)
 set(XMLTO_OPTS -m ${DOC_DIR}/manpage-normal.xsl -m ${DOC_DIR}/manpage-bold-literal.xsl man)
@@ -39,6 +40,8 @@ foreach (manfile IN LISTS MAN_NAMES)
     string(REGEX REPLACE \\.. .asciidoc docfile ${manfile})
     string(REGEX REPLACE \\.. .html htmlfile ${manfile})
 
+    set(manfile ${CMAKE_MANPAGE_OUTPUT_DIRECTORY}/${manfile})
+    set(htmlfile ${CMAKE_HTML_OUTPUT_DIRECTORY}/${htmlfile})
     set(docfile ${DOC_DIR}/${docfile})
 
     add_custom_command(OUTPUT ${manfile}


### PR DESCRIPTION
Previously every time running `make` or `make install`, commands will be ran to generate man files and html files even if *.asciidoc is not changed at all.