### PR TITLE
change from bzero(3) to memset(3) for better compatibility.

### DIFF
--- a/src/plugin.c
+++ b/src/plugin.c
@@ -308,7 +308,8 @@ get_local_port()
     }
 
     struct sockaddr_in serv_addr;
-    bzero((char *)&serv_addr, sizeof(serv_addr));
+    //bzero((char *)&serv_addr, sizeof(serv_addr)); /* replace bzero(3) to memset(3). which is more compatible to old systems */ 
+    memset(&serv_addr, 0, sizeof(serv_addr));
     serv_addr.sin_family      = AF_INET;
     serv_addr.sin_addr.s_addr = INADDR_ANY;
     serv_addr.sin_port        = 0;

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -308,7 +308,6 @@ get_local_port()
     }
 
     struct sockaddr_in serv_addr;
-    //bzero((char *)&serv_addr, sizeof(serv_addr)); /* replace bzero(3) to memset(3). which is more compatible to old systems */ 
     memset(&serv_addr, 0, sizeof(serv_addr));
     serv_addr.sin_family      = AF_INET;
     serv_addr.sin_addr.s_addr = INADDR_ANY;


### PR DESCRIPTION
bzero(3) is an old BSD compatibility function, and have a separated header file strings.h. So memset(3) maybe a better choice.