### PR TITLE
Change from network.target to network-online.target in systemd service files.

### DIFF
--- a/debian/shadowsocks-libev-local@.service
+++ b/debian/shadowsocks-libev-local@.service
@@ -12,7 +12,7 @@
 [Unit]
 Description=Shadowsocks-Libev Custom Client Service for %I
 Documentation=man:ss-local(1)
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple

--- a/debian/shadowsocks-libev-redir@.service
+++ b/debian/shadowsocks-libev-redir@.service
@@ -12,7 +12,7 @@
 [Unit]
 Description=Shadowsocks-Libev Custom Client Service Redir Mode for %I
 Documentation=man:ss-redir(1)
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple

--- a/debian/shadowsocks-libev-server@.service
+++ b/debian/shadowsocks-libev-server@.service
@@ -12,7 +12,7 @@
 [Unit]
 Description=Shadowsocks-Libev Custom Server Service for %I
 Documentation=man:ss-server(1)
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple

--- a/debian/shadowsocks-libev-tunnel@.service
+++ b/debian/shadowsocks-libev-tunnel@.service
@@ -12,7 +12,7 @@
 [Unit]
 Description=Shadowsocks-Libev Custom Client Service Tunnel Mode for %I
 Documentation=man:ss-tunnel(1)
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple

--- a/debian/shadowsocks-libev.service
+++ b/debian/shadowsocks-libev.service
@@ -11,7 +11,7 @@
 [Unit]
 Description=Shadowsocks-libev Default Server Service
 Documentation=man:shadowsocks-libev(8)
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple

--- a/rpm/SOURCES/systemd/shadowsocks-libev-local.service
+++ b/rpm/SOURCES/systemd/shadowsocks-libev-local.service
@@ -11,7 +11,7 @@
 [Unit]
 Description=Shadowsocks-libev Default Local Service
 Documentation=man:shadowsocks-libev(8)
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple

--- a/rpm/SOURCES/systemd/shadowsocks-libev-local@.service
+++ b/rpm/SOURCES/systemd/shadowsocks-libev-local@.service
@@ -12,7 +12,7 @@
 [Unit]
 Description=Shadowsocks-Libev Custom Client Service for %I
 Documentation=man:ss-local(1)
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple

--- a/rpm/SOURCES/systemd/shadowsocks-libev-redir@.service
+++ b/rpm/SOURCES/systemd/shadowsocks-libev-redir@.service
@@ -12,7 +12,7 @@
 [Unit]
 Description=Shadowsocks-Libev Custom Client Service Redir Mode for %I
 Documentation=man:ss-redir(1)
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple

--- a/rpm/SOURCES/systemd/shadowsocks-libev-server@.service
+++ b/rpm/SOURCES/systemd/shadowsocks-libev-server@.service
@@ -12,7 +12,7 @@
 [Unit]
 Description=Shadowsocks-Libev Custom Server Service for %I
 Documentation=man:ss-server(1)
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple

--- a/rpm/SOURCES/systemd/shadowsocks-libev-tunnel@.service
+++ b/rpm/SOURCES/systemd/shadowsocks-libev-tunnel@.service
@@ -12,7 +12,7 @@
 [Unit]
 Description=Shadowsocks-Libev Custom Client Service Tunnel Mode for %I
 Documentation=man:ss-tunnel(1)
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple

--- a/rpm/SOURCES/systemd/shadowsocks-libev.service
+++ b/rpm/SOURCES/systemd/shadowsocks-libev.service
@@ -11,7 +11,7 @@
 [Unit]
 Description=Shadowsocks-libev Default Server Service
 Documentation=man:shadowsocks-libev(8)
-After=network.target network-online.target 
+After=network-online.target network-online.target 
 
 [Service]
 Type=simple


### PR DESCRIPTION
Shadowsocks is a socks5 proxy program. It should run after network connection. In the old settings, Shadowsocks runs after network.target is booted by systemd. But I think it is not correct. Running network.target just means that services for maintaining network adapters are running. It does not mean network adapters have got IP and accepted or sent network packets. In some scenarios, for example laptop PC with WLAN, if I set shadowsocks-libev-local service start after system boots, it maybe does not work. Systemd cannot make sure network connection is OK after network.target starts. So I think Shadowsocks-libev services should started after network-online.target.   