### PR TITLE
Fix QoS

### DIFF
--- a/src/udprelay.c
+++ b/src/udprelay.c
@@ -496,7 +496,7 @@ create_server_socket(const char *host, const char *port)
         }
 #ifdef IP_TOS
         // Set QoS flag
-        int tos   = 46;
+        int tos   = 46 << 2;
         int proto = rp->ai_family == AF_INET6 ? IPPROTO_IP : IPPROTO_IPV6;
         setsockopt(server_sock, proto, IP_TOS, &tos, sizeof(tos));
 #endif
@@ -658,7 +658,7 @@ resolv_cb(struct sockaddr *addr, void *data)
 #endif
 #ifdef IP_TOS
                 // Set QoS flag
-                int tos   = 46;
+                int tos   = 46 << 2;
                 int proto = addr->sa_family == AF_INET6 ? IPPROTO_IP : IPPROTO_IPV6;
                 setsockopt(remotefd, proto, IP_TOS, &tos, sizeof(tos));
 #endif
@@ -846,7 +846,7 @@ remote_recv_cb(EV_P_ ev_io *w, int revents)
     }
 #ifdef IP_TOS
     // Set QoS flag
-    int tos   = 46;
+    int tos   = 46 << 2;
     int proto = remote_ctx->src_addr.ss_family == AF_INET6 ? IPPROTO_IP : IPPROTO_IPV6;
     setsockopt(src_fd, proto, IP_TOS, &tos, sizeof(tos));
 #endif
@@ -1179,7 +1179,7 @@ server_recv_cb(EV_P_ ev_io *w, int revents)
 #endif
 #ifdef IP_TOS
         // Set QoS flag
-        int tos = 46;
+        int tos = 46 << 2;
         setsockopt(remotefd, IPPROTO_IP, IP_TOS, &tos, sizeof(tos));
 #endif
 #ifdef SET_INTERFACE
@@ -1268,7 +1268,7 @@ server_recv_cb(EV_P_ ev_io *w, int revents)
 #endif
 #ifdef IP_TOS
                 // Set QoS flag
-                int tos   = 46;
+                int tos   = 46 << 2;
                 int proto = dst_addr.ss_family == AF_INET6 ? IPPROTO_IP : IPPROTO_IPV6;
                 setsockopt(remotefd, proto, IP_TOS, &tos, sizeof(tos));
 #endif


### PR DESCRIPTION
I suppose you want to set the DSCP value to 46, but the DSCP value is the first 6 bits of tos. (https://www.voip-info.org/diffserv)