### PR TITLE
Fix redir default cipher

### DIFF
--- a/src/redir.c
+++ b/src/redir.c
@@ -1074,7 +1074,7 @@ main(int argc, char **argv)
     }
 
     if (method == NULL) {
-        method = "rc4-md5";
+        method = "chacha20-ietf-poly1305";
     }
 
     if (timeout == NULL) {


### PR DESCRIPTION
The default encryption methods in doc and code for redir differ.