### PR TITLE
Fix of PATH_MAX for GNU/Hurd

### DIFF
--- a/src/manager.c
+++ b/src/manager.c
@@ -1131,8 +1131,9 @@ main(int argc, char **argv)
     }
 
     if (manager_address == NULL) {
-        manager_address = ss_malloc(PATH_MAX);
-        snprintf(manager_address, PATH_MAX, "%s/.ss-manager.socks", workdir);
+        size_t manager_address_size = strlen(workdir) + 20;
+        manager_address = ss_malloc(manager_address_size);
+        snprintf(manager_address, manager_address_size, "%s/.ss-manager.socks", workdir);
         LOGI("using the default manager address: %s", manager_address);
     }
 


### PR DESCRIPTION
PATH_MAX is not defined on each platform, and should be avoided.

Info:
- https://www.gnu.org/software/hurd/community/gsoc/project_ideas/maxpath.html
- https://www.gnu.org/software/hurd/hurd/porting/guidelines.html#PATH_MAX_tt_MAX_PATH_tt_MAXPATHL