### PR TITLE
Set cap_net_bind_service for docker

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -21,6 +21,7 @@ RUN set -ex \
       automake \
       build-base \
       c-ares-dev \
+      libcap \
       libev-dev \
       libtool \
       libsodium-dev \
@@ -32,6 +33,7 @@ RUN set -ex \
  && ./autogen.sh \
  && ./configure --prefix=/usr --disable-documentation \
  && make install \
+ && ls /usr/bin/ss-* | xargs -n1 setcap cap_net_bind_service+ep \
  && apk del .build-deps \
  # Runtime dependencies setup
  && apk add --no-cache \


### PR DESCRIPTION
Set cap_net_bind_service on ss-* binaries so they can be bound to privileged ports without root.
Every modern container storage driver supports this, the ones that don't will simply ignore it.