### PR TITLE
Remove unnecessary memmove

### DIFF
--- a/src/aead.c
+++ b/src/aead.c
@@ -617,9 +617,6 @@ aead_chunk_decrypt(cipher_ctx_t *ctx, uint8_t *p, uint8_t *c, uint8_t *n,
 
     sodium_increment(n, nlen);
 
-    if (*clen > chunk_len)
-        memmove(c, c + chunk_len, *clen - chunk_len);
-
     *clen = *clen - chunk_len;
 
     return CRYPTO_OK;
@@ -671,22 +668,27 @@ aead_decrypt(buffer_t *ciphertext, cipher_ctx_t *cipher_ctx, size_t capacity)
     }
 
     size_t plen = 0;
+    size_t cidx = 0;
     while (cipher_ctx->chunk->len > 0) {
         size_t chunk_clen = cipher_ctx->chunk->len;
         size_t chunk_plen = 0;
         err = aead_chunk_decrypt(cipher_ctx,
                                  (uint8_t *)plaintext->data + plen,
-                                 (uint8_t *)cipher_ctx->chunk->data,
+                                 (uint8_t *)cipher_ctx->chunk->data + cidx,
                                  cipher_ctx->nonce, &chunk_plen, &chunk_clen);
         if (err == CRYPTO_ERROR) {
             return err;
         } else if (err == CRYPTO_NEED_MORE) {
             if (plen == 0)
                 return err;
-            else
+            else{
+                memmove((uint8_t *)cipher_ctx->chunk->data, 
+			(uint8_t *)cipher_ctx->chunk->data + cidx, chunk_clen);
                 break;
+            }
         }
         cipher_ctx->chunk->len = chunk_clen;
+        cidx += cipher_ctx->cipher->tag_len * 2 + CHUNK_SIZE_LEN + chunk_plen;
         plen                  += chunk_plen;
     }
     plaintext->len = plen;


### PR DESCRIPTION
Before patch, after one chunk decoded, we do a memmove.
After patch, after all complete chunk decoded, we do a memmove.