### PR TITLE
server: fix setTosFromConnmark typo

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -656,7 +656,7 @@ setTosFromConnmark(remote_t *remote, server_t *server)
         len = sizeof(sin);
         if (getsockname(remote->fd, (struct sockaddr *)&sin, &len) == 0) {
             struct sockaddr_storage from_addr;
-            len = sizeof from_addr;
+            len = sizeof(from_addr);
             if (getpeername(remote->fd, (struct sockaddr *)&from_addr, &len) == 0) {
                 if ((server->tracker = (struct dscptracker *)ss_malloc(sizeof(struct dscptracker)))) {
                     if ((server->tracker->ct = nfct_new())) {


### PR DESCRIPTION
BTW, unless first set a iptables rule like "iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT",

Tos would not work on ubuntu 18.04.

For more information, please refer https://askubuntu.com/questions/1045772/iptables-rule-that-uses-state