### PR TITLE
server: fix setTosFromConnmark typo

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -654,10 +654,10 @@ setTosFromConnmark(remote_t *remote, server_t *server)
         socklen_t len;
         struct sockaddr_storage sin;
         len = sizeof(sin);
-        if (getsockname(remote->fd, (struct sockaddr *)&sin, &len) == 0) {
+        if (getpeername(remote->fd, (struct sockaddr *)&sin, &len) == 0) {
             struct sockaddr_storage from_addr;
             len = sizeof from_addr;
-            if (getpeername(remote->fd, (struct sockaddr *)&from_addr, &len) == 0) {
+            if (getsockname(remote->fd, (struct sockaddr *)&from_addr, &len) == 0) {
                 if ((server->tracker = (struct dscptracker *)ss_malloc(sizeof(struct dscptracker)))) {
                     if ((server->tracker->ct = nfct_new())) {
                         // Build conntrack query SELECT


### PR DESCRIPTION
Server made a connection to remote, remote replied with that connection.

nf_conntrack module would check orig-dst and orig-src by default and find every connection that dst and src matches reply-src and reply-dst, respectively.

more information please refer to https://www.spinics.net/lists/netfilter/msg57842.html

As a result, src and dst should be swapped to make nf_conntrack find the connection.