### PR TITLE
crypto: lower bloom filter error rate

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -80,7 +80,7 @@ typedef mbedtls_md_info_t digest_type_t;
 #endif
 
 #ifndef BF_ERROR_RATE_FOR_SERVER
-#define BF_ERROR_RATE_FOR_SERVER 1e-6
+#define BF_ERROR_RATE_FOR_SERVER 1e-10
 #endif
 
 #ifndef BF_ERROR_RATE_FOR_CLIENT


### PR DESCRIPTION
As in issue #2607 , we have PING PONG bloom filters.
if anyone is full, we reset the other one.
As a result, the full bloom filter would be checked 5e5 times at current setup.



before patch:
full bloom filter error rate before reset 1-(1-1e-6)^5e5=1-0.606=0.394

after patch:
1-(1-1e-10)^5e5=1-0.99995=5e-5

