### PR TITLE
ppbloom: save free() and subsequent init() overhead

### DIFF
--- a/src/ppbloom.c
+++ b/src/ppbloom.c
@@ -88,8 +88,7 @@ ppbloom_add(const void *buffer, int len)
     if (bloom_count[current] >= entries) {
         bloom_count[current] = 0;
         current              = current == PING ? PONG : PING;
-        bloom_free(ppbloom + current);
-        bloom_init(ppbloom + current, entries, error);
+        bloom_reset(ppbloom + current);
     }
 
     return 0;


### PR DESCRIPTION
init utilizes calloc which malloc and memset.

need cherry-pick commit of libbloom

