### PR TITLE
Use classic mode to install shadowsocks-libev

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ https://snapcraft.io/core
 Stable channel:
 
 ```bash
-sudo snap install shadowsocks-libev
+sudo snap install shadowsocks-libev --classic
 ```
 
 Edge channel:
 
 ```bash
-sudo snap install shadowsocks-libev --edge
+sudo snap install shadowsocks-libev --classic --edge
 ```
 
 ## Installation


### PR DESCRIPTION
This can prevent `Too many open files` error from happening due to sandboxing.

Do note that classic mode is not recommended, however, the only way I can find to get around that is to run `snap run --shell shadowsocks-libev.ss-server` and tweak nlimits there, which does not seem to be a good solution. I do wonder if there is a better solution.