### PR TITLE
Fix a tiny memory leak

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -546,6 +546,7 @@ get_default_conf(void)
         return userconf;
 
     // If not, fall back to the system-wide config.
+    free(userconf);
     return sysconf;
 #else
     return "config.json";


### PR DESCRIPTION
free userconf since it is not needed any more if fall back to the system-wide config.