### PR TITLE
Add Dockerfile timezone, Update readme.

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -11,7 +11,7 @@ ENV PASSWORD=
 ENV METHOD      aes-256-gcm
 ENV TIMEOUT     300
 ENV DNS_ADDRS    8.8.8.8,8.8.4.4
-ENV TZ Asia/Shanghai
+ENV TZ UTC
 ENV ARGS=
 
 COPY . /tmp/repo

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -11,6 +11,7 @@ ENV PASSWORD=
 ENV METHOD      aes-256-gcm
 ENV TIMEOUT     300
 ENV DNS_ADDRS    8.8.8.8,8.8.4.4
+ENV TZ Asia/Shanghai
 ENV ARGS=
 
 COPY . /tmp/repo
@@ -39,6 +40,7 @@ RUN set -ex \
  && apk add --no-cache \
       ca-certificates \
       rng-tools \
+      tzdata \
       $(scanelf --needed --nobanner /usr/bin/ss-* \
       | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
       | sort -u) \

--- a/docker/alpine/README.md
+++ b/docker/alpine/README.md
@@ -63,7 +63,7 @@ Besides `PASSWORD`, the image also defines the following environment variables t
 * `METHOD`: encryption method to use, defaults to `aes-256-gcm`
 * `TIMEOUT`: defaults to `300`
 * `DNS_ADDRS`: DNS servers to redirect NS lookup requests to, defaults to `8.8.8.8,8.8.4.4`
-* `TZ`: Timezone, defaults to `Asia/Shanghai`
+* `TZ`: Timezone, defaults to `UTC`
 
 Additional arguments supported by `ss-server` can be passed with the environment variable `ARGS`, for instance to start in verbose mode:
 ```bash

--- a/docker/alpine/README.md
+++ b/docker/alpine/README.md
@@ -63,6 +63,7 @@ Besides `PASSWORD`, the image also defines the following environment variables t
 * `METHOD`: encryption method to use, defaults to `aes-256-gcm`
 * `TIMEOUT`: defaults to `300`
 * `DNS_ADDRS`: DNS servers to redirect NS lookup requests to, defaults to `8.8.8.8,8.8.4.4`
+* `TZ`: Timezone, defaults to `Asia/Shanghai`
 
 Additional arguments supported by `ss-server` can be passed with the environment variable `ARGS`, for instance to start in verbose mode:
 ```bash


### PR DESCRIPTION
Hi,

Due to alpine's default timezone is a UTC which may give the wrong logs. I've added an ENV to set the correct timezone. 

* before
![image](https://user-images.githubusercontent.com/16236902/77141224-15788200-6ab7-11ea-8c02-a9825052a676.png)

* after 
![image](https://user-images.githubusercontent.com/16236902/77141231-19a49f80-6ab7-11ea-8e37-0aee9fdde8cd.png)
