### PR TITLE
cmake: fix build issues when this project is built as dependency of other CMake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,12 +10,12 @@ project(${PROJECT_NAME} VERSION ${PROJECT_VERSION})
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 
-#set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/out)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
-set(RUNTIME_SHARED_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/shared/bin)
+#set(PROJECT_BINARY_DIR ${PROJECT_SOURCE_DIR}/out)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
+set(RUNTIME_SHARED_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/shared/bin)
 
 set(CMAKE_MACOSX_RPATH TRUE)
 
@@ -43,19 +43,19 @@ if (NOT WITH_EMBEDDED_SRC)
 endif ()
 
 # Run platform tests
-include(${CMAKE_SOURCE_DIR}/cmake/configure.cmake)
-configure_file(${CMAKE_SOURCE_DIR}/cmake/config.h.cmake ${CMAKE_BINARY_DIR}/src/config.h)
-add_definitions(-I$(CMAKE_BINARY_DIR)/src)
+include(${PROJECT_SOURCE_DIR}/cmake/configure.cmake)
+configure_file(${PROJECT_SOURCE_DIR}/cmake/config.h.cmake ${PROJECT_BINARY_DIR}/src/config.h)
+add_definitions(-I${PROJECT_BINARY_DIR}/src)
 add_definitions(-DHAVE_CONFIG_H)
 
 # pkg-config
 configure_file(
-        ${CMAKE_SOURCE_DIR}/cmake/shadowsocks-libev.pc.cmake
-        ${CMAKE_BINARY_DIR}/pkgconfig/shadowsocks-libev.pc
+        ${PROJECT_SOURCE_DIR}/cmake/shadowsocks-libev.pc.cmake
+        ${PROJECT_BINARY_DIR}/pkgconfig/shadowsocks-libev.pc
         @ONLY
 )
 install(FILES
-        ${CMAKE_BINARY_DIR}/pkgconfig/shadowsocks-libev.pc
+        ${PROJECT_BINARY_DIR}/pkgconfig/shadowsocks-libev.pc
         DESTINATION lib/pkgconfig
         )
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -22,10 +22,10 @@ if (EXISTS ${XMLTO_CATALOG_DIR_MACOS})
     message(STATUS "Detect xmlto catalog dir ${XMLTO_CATALOG_DIR_MACOS}")
 endif ()
 
-set(CMAKE_MANPAGE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/man)
-set(CMAKE_HTML_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/html)
+set(CMAKE_MANPAGE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/man)
+set(CMAKE_HTML_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/html)
 
-set(DOC_DIR ${CMAKE_SOURCE_DIR}/doc)
+set(DOC_DIR ${PROJECT_SOURCE_DIR}/doc)
 set(XMLTO_OPTS -m ${DOC_DIR}/manpage-normal.xsl -m ${DOC_DIR}/manpage-bold-literal.xsl man)
 set(ASCIIDOC_XML_OPTS -b docbook -d manpage -f ${DOC_DIR}/asciidoc.conf -aversion=${PROJECT_VERSION})
 set(ASCIIDOC_HTML_OPTS -b html4 -d article -f ${DOC_DIR}/asciidoc.conf -aversion=${PROJECT_VERSION})
@@ -50,7 +50,7 @@ foreach (manfile IN LISTS MAN_NAMES)
             # After we built the manpage, the xmlfile is nolongger needed
             COMMAND ${CMAKE_COMMAND} -E remove ${xmlfile}
             DEPENDS ${docfile}
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/man
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/man
             COMMENT "Building manpage ${manfile}"
             VERBATIM)
     list(APPEND MAN_FILES ${manfile})
@@ -58,7 +58,7 @@ foreach (manfile IN LISTS MAN_NAMES)
     add_custom_command(OUTPUT ${htmlfile}
             COMMAND ${ASCIIDOC_EXECUTABLE} ${ASCIIDOC_HTML_OPTS} -o ${htmlfile} ${docfile}
             DEPENDS ${docfile}
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/html
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/html
             COMMENT "Building htmlfile ${htmlfile}"
             VERBATIM)
     list(APPEND HTML_FILES ${htmlfile})
@@ -71,11 +71,11 @@ add_custom_target(doc-html ALL DEPENDS ${HTML_FILES})
 if (NOT WITH_DOC_MAN)
     set_target_properties(doc-man PROPERTIES EXCLUDE_FROM_ALL TRUE)
 else ()
-    install(DIRECTORY ${CMAKE_BINARY_DIR}/man/
+    install(DIRECTORY ${PROJECT_BINARY_DIR}/man/
             DESTINATION share/man/man1
             FILES_MATCHING PATTERN "*.1"
             )
-    install(DIRECTORY ${CMAKE_BINARY_DIR}/man/
+    install(DIRECTORY ${PROJECT_BINARY_DIR}/man/
             DESTINATION share/man/man8
             FILES_MATCHING PATTERN "*.8"
             )
@@ -83,10 +83,10 @@ endif ()
 if (NOT WITH_DOC_HTML)
     set_target_properties(doc-html PROPERTIES EXCLUDE_FROM_ALL TRUE)
 else ()
-    install(DIRECTORY ${CMAKE_BINARY_DIR}/html/
+    install(DIRECTORY ${PROJECT_BINARY_DIR}/html/
             DESTINATION share/doc/${PROJECT_NAME})
 endif ()
 
 # This is required for custom command
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/man)
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/html)
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/man)
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/html)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -175,6 +175,8 @@ target_compile_definitions(ss-local PUBLIC -DMODULE_LOCAL)
 target_compile_definitions(ss-redir PUBLIC -DMODULE_REDIR)
 target_compile_definitions(shadowsocks-libev PUBLIC -DMODULE_LOCAL -DLIB_ONLY)
 
+target_include_directories(shadowsocks-libev PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 target_link_libraries(ss-server cork ipset ${DEPS})
 target_link_libraries(ss-tunnel cork ${DEPS})
 target_link_libraries(ss-manager m bloom cork ${LIBEV} ${LIBUDNS})
@@ -205,6 +207,8 @@ target_compile_definitions(ss-manager-shared PUBLIC -DMODULE_MANAGER)
 target_compile_definitions(ss-local-shared PUBLIC -DMODULE_LOCAL)
 target_compile_definitions(ss-redir-shared PUBLIC -DMODULE_REDIR)
 target_compile_definitions(shadowsocks-libev-shared PUBLIC -DMODULE_LOCAL)
+
+target_include_directories(shadowsocks-libev-shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(ss-server-shared ${DEPS_SHARED})
 target_link_libraries(ss-tunnel-shared ${DEPS_SHARED})


### PR DESCRIPTION
Since this project also generates shared libraries, it'd be great if it can be used as dependency of other CMake projects.

But currently it doesn't work because the CMakeLists.txt uses `CMAKE_SOURCE_DIR` and `CMAKE_BINARY_DIR` which always refer to the top-level project source/binary directories.

I changed these variables to `PROJECT_SOURCE_DIR` and `PROJECT_BINARY_DIR`. Now it works both ways, as standalone project and as a part of other projects. Ref (https://stackoverflow.com/questions/22214349/modify-cmake-source-dir)

I also fixed a bug [here](https://github.com/shadowsocks/shadowsocks-libev/blob/b9ce095ee70ca19cafac82da43afb9de2d4a02e7/CMakeLists.txt#L48). Variables should be encapsulated with `${...}` rather than`$(...)`.

In addition, `include_directories` properties are not set for the shared libraries(libshadowsocks.so and libshadowsocks.a), which causes `shadowsocks.h` not found when building targets dependent on these two shared libraries. This issue is also fixed in this PR.