### PR TITLE
debian/rules: Fix #2675

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -20,8 +20,5 @@ override_dh_auto_configure:
 override_dh_installchangelogs:
 	dh_installchangelogs -XChanges
 
-override_dh_missing:
-	dh_missing --fail-missing
-
 %:
 	dh $@


### PR DESCRIPTION
Regression caused by commit [0d96da4].