### PR TITLE
Add `xchacha20-ietf-poly1305` to docs and completions

### DIFF
--- a/completions/bash/ss-local
+++ b/completions/bash/ss-local
@@ -2,7 +2,7 @@ _ss_local()
 {
     local cur prev opts ciphers
     opts='-s -p -l -k -m -a -f -t -c -n -i -b -u -U -v -h --reuse-port --fast-open --acl --mtu --mptcp --no-delay --key --plugin --plugin-opts --help'
-    ciphers='rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf'
+    ciphers='rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 xchacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf'
     cur=${COMP_WORDS[COMP_CWORD]}
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     case "$prev" in

--- a/completions/bash/ss-manager
+++ b/completions/bash/ss-manager
@@ -2,7 +2,7 @@ _ss_manager()
 {
     local cur prev opts ciphers
     opts='-s -p -l -k -m -a -f -t -c -n -i -b -u -U -v -h --reuse-port --manager-address --executable --mtu --mptcp --plugin --plugin-opts --help'
-    ciphers='rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf'
+    ciphers='rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 xchacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf'
     cur=${COMP_WORDS[COMP_CWORD]}
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     case "$prev" in

--- a/completions/bash/ss-redir
+++ b/completions/bash/ss-redir
@@ -2,7 +2,7 @@ _ss_redir()
 {
     local cur prev opts ciphers
     opts='-s -p -l -k -m -a -f -t -c -n -b -u -U -v -h --reuse-port --mtu --mptcp --key --plugin --plugin-opts --help'
-    ciphers='rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf'
+    ciphers='rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 xchacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf'
     cur=${COMP_WORDS[COMP_CWORD]}
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     case "$prev" in

--- a/completions/bash/ss-server
+++ b/completions/bash/ss-server
@@ -2,7 +2,7 @@ _ss_server()
 {
     local cur prev opts ciphers
     opts='-s -p -l -k -m -a -f -t -c -n -i -b -u -U -6 -d -v -h --reuse-port --fast-open --acl --manager-address --mtu --mptcp --no-delay --key --plugin --plugin-opts --help'
-    ciphers='rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf'
+    ciphers='rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 xchacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf'
     COMPREPLY=()
     cur=${COMP_WORDS[COMP_CWORD]}
     prev="${COMP_WORDS[COMP_CWORD-1]}"

--- a/completions/bash/ss-tunnel
+++ b/completions/bash/ss-tunnel
@@ -2,7 +2,7 @@ _ss_tunnel()
 {
     local cur prev opts ciphers
     opts='-s -p -l -k -m -a -f -t -c -n -i -b -u -U -L -v -h --reuse-port --mtu --mptcp --key --plugin --plugin-opts --help'
-    ciphers='rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf'
+    ciphers='rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 xchacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf'
     cur=${COMP_WORDS[COMP_CWORD]}
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     compopt +o nospace

--- a/completions/zsh/_ss-local
+++ b/completions/zsh/_ss-local
@@ -1,7 +1,7 @@
 #compdef ss-local
 
 local ciphers
-ciphers='(rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf)'
+ciphers='(rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 xchacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf)'
 
 _arguments "-h::" \
            "-s:server host:_hosts" \

--- a/completions/zsh/_ss-manager
+++ b/completions/zsh/_ss-manager
@@ -1,7 +1,7 @@
 #compdef ss-manager
 
 local ciphers
-ciphers='(rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf)'
+ciphers='(rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 xchacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf)'
 
 _arguments "-h::" \
            "-s:server host:_hosts" \

--- a/completions/zsh/_ss-redir
+++ b/completions/zsh/_ss-redir
@@ -1,7 +1,7 @@
 #compdef ss-redir
 
 local ciphers
-ciphers='(rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf)'
+ciphers='(rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 xchacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf)'
 
 _arguments "-h::" \
            "-s:server host:_hosts" \

--- a/completions/zsh/_ss-server
+++ b/completions/zsh/_ss-server
@@ -1,7 +1,7 @@
 #compdef ss-server
 
 local ciphers
-ciphers='(rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf)'
+ciphers='(rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 xchacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf)'
 
 _arguments "-h::" \
            "-s:server host:_hosts" \

--- a/completions/zsh/_ss-tunnel
+++ b/completions/zsh/_ss-tunnel
@@ -1,7 +1,7 @@
 #compdef ss-tunnel
 
 local ciphers
-ciphers='(rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf)'
+ciphers='(rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 xchacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf)'
 
 _arguments "-h::" \
            "-s:server host:_hosts" \

--- a/doc/shadowsocks-libev.asciidoc
+++ b/doc/shadowsocks-libev.asciidoc
@@ -56,7 +56,7 @@ Not available in manager mode.
 -m <encrypt_method>::
 Set the cipher.
 +
-*Shadowsocks-libev* accepts 18 different ciphers:
+*Shadowsocks-libev* accepts 19 different ciphers:
 +
 aes-128-gcm, aes-192-gcm, aes-256-gcm,
 rc4-md5, aes-128-cfb, aes-192-cfb, aes-256-cfb,

--- a/doc/shadowsocks-libev.asciidoc
+++ b/doc/shadowsocks-libev.asciidoc
@@ -62,7 +62,8 @@ aes-128-gcm, aes-192-gcm, aes-256-gcm,
 rc4-md5, aes-128-cfb, aes-192-cfb, aes-256-cfb,
 aes-128-ctr, aes-192-ctr, aes-256-ctr, bf-cfb,
 camellia-128-cfb, camellia-192-cfb, camellia-256-cfb,
-chacha20-ietf-poly1305, salsa20, chacha20 and chacha20-ietf.
+chacha20-ietf-poly1305, xchacha20-ietf-poly1305,
+salsa20, chacha20 and chacha20-ietf.
 +
 The default cipher is 'chacha20-ietf-poly1305'.
 +

--- a/doc/ss-local.asciidoc
+++ b/doc/ss-local.asciidoc
@@ -57,7 +57,8 @@ aes-128-gcm, aes-192-gcm, aes-256-gcm,
 rc4-md5, aes-128-cfb, aes-192-cfb, aes-256-cfb,
 aes-128-ctr, aes-192-ctr, aes-256-ctr, bf-cfb,
 camellia-128-cfb, camellia-192-cfb, camellia-256-cfb,
-chacha20-ietf-poly1305, salsa20, chacha20 and chacha20-ietf.
+chacha20-ietf-poly1305, xchacha20-ietf-poly1305,
+salsa20, chacha20 and chacha20-ietf.
 +
 The default cipher is 'chacha20-ietf-poly1305'.
 +

--- a/doc/ss-local.asciidoc
+++ b/doc/ss-local.asciidoc
@@ -51,7 +51,7 @@ Set the key directly. The key should be encoded with URL-safe Base64.
 -m <encrypt_method>::
 Set the cipher.
 +
-*Shadowsocks-libev* accepts 18 different ciphers:
+*Shadowsocks-libev* accepts 19 different ciphers:
 +
 aes-128-gcm, aes-192-gcm, aes-256-gcm,
 rc4-md5, aes-128-cfb, aes-192-cfb, aes-256-cfb,

--- a/doc/ss-manager.asciidoc
+++ b/doc/ss-manager.asciidoc
@@ -43,7 +43,7 @@ Set the password. The server and the client should use the same password.
 -m <encrypt_method>::
 Set the cipher.
 +
-*Shadowsocks-libev* accepts 18 different ciphers:
+*Shadowsocks-libev* accepts 19 different ciphers:
 +
 aes-128-gcm, aes-192-gcm, aes-256-gcm,
 rc4-md5, aes-128-cfb, aes-192-cfb, aes-256-cfb,

--- a/doc/ss-manager.asciidoc
+++ b/doc/ss-manager.asciidoc
@@ -49,7 +49,8 @@ aes-128-gcm, aes-192-gcm, aes-256-gcm,
 rc4-md5, aes-128-cfb, aes-192-cfb, aes-256-cfb,
 aes-128-ctr, aes-192-ctr, aes-256-ctr, bf-cfb,
 camellia-128-cfb, camellia-192-cfb, camellia-256-cfb,
-chacha20-ietf-poly1305, salsa20, chacha20 and chacha20-ietf.
+chacha20-ietf-poly1305, xchacha20-ietf-poly1305,
+salsa20, chacha20 and chacha20-ietf.
 +
 The default cipher is 'chacha20-ietf-poly1305'.
 +

--- a/doc/ss-redir.asciidoc
+++ b/doc/ss-redir.asciidoc
@@ -56,7 +56,8 @@ aes-128-gcm, aes-192-gcm, aes-256-gcm,
 rc4-md5, aes-128-cfb, aes-192-cfb, aes-256-cfb,
 aes-128-ctr, aes-192-ctr, aes-256-ctr, bf-cfb,
 camellia-128-cfb, camellia-192-cfb, camellia-256-cfb,
-chacha20-ietf-poly1305, salsa20, chacha20 and chacha20-ietf.
+chacha20-ietf-poly1305, xchacha20-ietf-poly1305,
+salsa20, chacha20 and chacha20-ietf.
 +
 The default cipher is 'chacha20-ietf-poly1305'.
 +

--- a/doc/ss-redir.asciidoc
+++ b/doc/ss-redir.asciidoc
@@ -50,7 +50,7 @@ Set the key directly. The key should be encoded with URL-safe Base64.
 -m <encrypt_method>::
 Set the cipher.
 +
-*Shadowsocks-libev* accepts 18 different ciphers:
+*Shadowsocks-libev* accepts 19 different ciphers:
 +
 aes-128-gcm, aes-192-gcm, aes-256-gcm,
 rc4-md5, aes-128-cfb, aes-192-cfb, aes-256-cfb,

--- a/doc/ss-server.asciidoc
+++ b/doc/ss-server.asciidoc
@@ -48,7 +48,7 @@ Set the key directly. The key should be encoded with URL-safe Base64.
 -m <encrypt_method>::
 Set the cipher.
 +
-*Shadowsocks-libev* accepts 18 different ciphers:
+*Shadowsocks-libev* accepts 19 different ciphers:
 +
 aes-128-gcm, aes-192-gcm, aes-256-gcm,
 rc4-md5, aes-128-cfb, aes-192-cfb, aes-256-cfb,

--- a/doc/ss-server.asciidoc
+++ b/doc/ss-server.asciidoc
@@ -54,7 +54,8 @@ aes-128-gcm, aes-192-gcm, aes-256-gcm,
 rc4-md5, aes-128-cfb, aes-192-cfb, aes-256-cfb,
 aes-128-ctr, aes-192-ctr, aes-256-ctr, bf-cfb,
 camellia-128-cfb, camellia-192-cfb, camellia-256-cfb,
-chacha20-ietf-poly1305, salsa20, chacha20 and chacha20-ietf.
+chacha20-ietf-poly1305, xchacha20-ietf-poly1305,
+salsa20, chacha20 and chacha20-ietf.
 +
 If built with PolarSSL or custom OpenSSL libraries, some of
 these ciphers may not work.

--- a/doc/ss-tunnel.asciidoc
+++ b/doc/ss-tunnel.asciidoc
@@ -56,7 +56,8 @@ aes-128-gcm, aes-192-gcm, aes-256-gcm,
 rc4-md5, aes-128-cfb, aes-192-cfb, aes-256-cfb,
 aes-128-ctr, aes-192-ctr, aes-256-ctr, bf-cfb,
 camellia-128-cfb, camellia-192-cfb, camellia-256-cfb,
-chacha20-ietf-poly1305, salsa20, chacha20 and chacha20-ietf.
+chacha20-ietf-poly1305, xchacha20-ietf-poly1305,
+salsa20, chacha20 and chacha20-ietf.
 +
 The default cipher is 'chacha20-ietf-poly1305'.
 +

--- a/doc/ss-tunnel.asciidoc
+++ b/doc/ss-tunnel.asciidoc
@@ -50,7 +50,7 @@ Set the key directly. The key should be encoded with URL-safe Base64.
 -m <encrypt_method>::
 Set the cipher.
 +
-*Shadowsocks-libev* accepts 18 different ciphers:
+*Shadowsocks-libev* accepts 19 different ciphers:
 +
 aes-128-gcm, aes-192-gcm, aes-256-gcm,
 rc4-md5, aes-128-cfb, aes-192-cfb, aes-256-cfb,


### PR DESCRIPTION
### Completions
#### bash
```bash
    ciphers='rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 xchacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf'
```
#### zsh
```zsh
ciphers='(rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 xchacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf)'
```

### Docs
```asciidoc
-m <encrypt_method>::
Set the cipher.
+
*Shadowsocks-libev* accepts 19 different ciphers:
+
aes-128-gcm, aes-192-gcm, aes-256-gcm,
rc4-md5, aes-128-cfb, aes-192-cfb, aes-256-cfb,
aes-128-ctr, aes-192-ctr, aes-256-ctr, bf-cfb,
camellia-128-cfb, camellia-192-cfb, camellia-256-cfb,
chacha20-ietf-poly1305, xchacha20-ietf-poly1305,
salsa20, chacha20 and chacha20-ietf.
+
The default cipher is 'chacha20-ietf-poly1305'.
+
If built with PolarSSL or custom OpenSSL libraries, some of
these ciphers may not work.
```