### PR TITLE
Fix workflow build to make docker release with tags or edge for master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,24 +2,44 @@ name: build
 
 on:
   push:
-    paths:
-      - ".github/workflows/build.yml"
-      - 'Changes'
+    push:
+      branches:
+        - master
+      tags:
+        - v*
+        - latest
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: crazy-max/ghaction-docker-buildx@v3
         with:
           buildx-version: v0.4.1
-      - run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-      - run: git submodule update --init
-      - run: |
+
+      - name: update submodules
+        run: git submodule update --init
+
+      - name: login docker
+        run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: build edge image
+        if: github.ref == 'refs/heads/master'
+        run: |
           docker buildx build \
             --push \
             --platform=linux/arm64,linux/amd64 \
             -f=docker/alpine/Dockerfile \
-            -t=${{ github.repository }} \
+            -t=${{ github.repository }}:edge \
+            .
+      - name: build version image
+        if: github.ref != 'refs/heads/master'
+        run: |
+          docker buildx build \
+            --push \
+            --platform=linux/arm64,linux/amd64 \
+            -f=docker/alpine/Dockerfile \
+            -t=${{ github.repository }}:$(echo ${{ github.ref }} | sed -E 's|refs/tags/||') \
             .


### PR DESCRIPTION
fix #2719

before merge，should stop autobuild in docker hub (it may be overwrites). 

when next release, just tag new version, but have to tag `latest` too.

https://hub.docker.com/r/morlay/shadowsocks-libev/tags