### PR TITLE
Add missing header for TCP_NODELAY.

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -38,6 +38,7 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #endif
 #ifdef LIB_ONLY
 #include "shadowsocks.h"

--- a/src/server.c
+++ b/src/server.c
@@ -40,6 +40,7 @@
 #include <errno.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <pthread.h>
 #include <sys/un.h>
 #endif

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -34,6 +34,7 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <pthread.h>
 #endif
 #ifdef HAVE_CONFIG_H


### PR DESCRIPTION
It seems that the macro was indirectly included so the code could be successfully compiled.

For Cygwin, the include path was `net/if.h` ->`cygwin/if.h` -> `cygwin/socket.h`. However, the definition of `TCP_NODELAY` in `cygwin/socket.h` has been removed in [a recent commit](https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;h=e037192b505b4f233fca9a6deafc9797210f6693). So now compilation fails when I tried to build the project with Cygwin:

```
/home/[stripped]/shadowsocks-libev/src/local.c:1022:41: error: ‘TCP_NODELAY’ undeclared (first use in this function); did you mean ‘O_NDELAY’?
 1022 |         setsockopt(server->fd, SOL_TCP, TCP_NODELAY, &opt, sizeof(opt));
      |                                         ^~~~~~~~~~~
      |                                         O_NDELAY
```