### PR TITLE
Add TPROXY support for TCP (ss-redir)

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,157 @@ The latest shadowsocks-libev has provided a *redir* mode. You can configure your
     # Start the shadowsocks-redir
     ss-redir -u -c /etc/config/shadowsocks.json -f /var/run/shadowsocks.pid
 
+## Transparent proxy (pure tproxy)
+
+Executing this script on the linux host can proxy all outgoing traffic of this machine (except the traffic sent to the reserved address). Other hosts under the same LAN can also change their default gateway to the ip of this linux host (at the same time change the dns server to 1.1.1.1 or 8.8.8.8, etc.) to proxy their outgoing traffic.
+
+> Of course, the ipv6 proxy is similar, just change `iptables` to `ip6tables`, `ip` to `ip -6`, `127.0.0.1` to `::1`, and other details.
+
+```shell
+#!/bin/bash
+
+start_ssredir() {
+    # please modify MyIP, MyPort, etc.
+    (ss-redir -s MyIP -p MyPort -m MyMethod -k MyPasswd -b 127.0.0.1 -l 60080 --no-delay -u -T -v </dev/null &>>/var/log/ss-redir.log &)
+}
+
+stop_ssredir() {
+    kill -9 $(pidof ss-redir) &>/dev/null
+}
+
+start_iptables() {
+    ##################### SSREDIR #####################
+    iptables -t mangle -N SSREDIR
+
+    # connection-mark -> packet-mark
+    iptables -t mangle -A SSREDIR -j CONNMARK --restore-mark
+    iptables -t mangle -A SSREDIR -m mark --mark 0x2333 -j RETURN
+
+    # please modify MyIP, MyPort, etc.
+    # ignore traffic sent to ss-server
+    iptables -t mangle -A SSREDIR -p tcp -d MyIP --dport MyPort -j RETURN
+    iptables -t mangle -A SSREDIR -p udp -d MyIP --dport MyPort -j RETURN
+
+    # ignore traffic sent to reserved addresses
+    iptables -t mangle -A SSREDIR -d 0.0.0.0/8          -j RETURN
+    iptables -t mangle -A SSREDIR -d 10.0.0.0/8         -j RETURN
+    iptables -t mangle -A SSREDIR -d 100.64.0.0/10      -j RETURN
+    iptables -t mangle -A SSREDIR -d 127.0.0.0/8        -j RETURN
+    iptables -t mangle -A SSREDIR -d 169.254.0.0/16     -j RETURN
+    iptables -t mangle -A SSREDIR -d 172.16.0.0/12      -j RETURN
+    iptables -t mangle -A SSREDIR -d 192.0.0.0/24       -j RETURN
+    iptables -t mangle -A SSREDIR -d 192.0.2.0/24       -j RETURN
+    iptables -t mangle -A SSREDIR -d 192.88.99.0/24     -j RETURN
+    iptables -t mangle -A SSREDIR -d 192.168.0.0/16     -j RETURN
+    iptables -t mangle -A SSREDIR -d 198.18.0.0/15      -j RETURN
+    iptables -t mangle -A SSREDIR -d 198.51.100.0/24    -j RETURN
+    iptables -t mangle -A SSREDIR -d 203.0.113.0/24     -j RETURN
+    iptables -t mangle -A SSREDIR -d 224.0.0.0/4        -j RETURN
+    iptables -t mangle -A SSREDIR -d 240.0.0.0/4        -j RETURN
+    iptables -t mangle -A SSREDIR -d 255.255.255.255/32 -j RETURN
+
+    # mark the first packet of the connection
+    iptables -t mangle -A SSREDIR -p tcp --syn                      -j MARK --set-mark 0x2333
+    iptables -t mangle -A SSREDIR -p udp -m conntrack --ctstate NEW -j MARK --set-mark 0x2333
+
+    # packet-mark -> connection-mark
+    iptables -t mangle -A SSREDIR -j CONNMARK --save-mark
+
+    ##################### OUTPUT #####################
+    # proxy the outgoing traffic from this machine
+    iptables -t mangle -A OUTPUT -p tcp -m addrtype --src-type LOCAL ! --dst-type LOCAL -j SSREDIR
+    iptables -t mangle -A OUTPUT -p udp -m addrtype --src-type LOCAL ! --dst-type LOCAL -j SSREDIR
+
+    ##################### PREROUTING #####################
+    # proxy traffic passing through this machine (other->other)
+    iptables -t mangle -A PREROUTING -p tcp -m addrtype ! --src-type LOCAL ! --dst-type LOCAL -j SSREDIR
+    iptables -t mangle -A PREROUTING -p udp -m addrtype ! --src-type LOCAL ! --dst-type LOCAL -j SSREDIR
+
+    # hand over the marked package to TPROXY for processing
+    iptables -t mangle -A PREROUTING -p tcp -m mark --mark 0x2333 -j TPROXY --on-ip 127.0.0.1 --on-port 60080
+    iptables -t mangle -A PREROUTING -p udp -m mark --mark 0x2333 -j TPROXY --on-ip 127.0.0.1 --on-port 60080
+}
+
+stop_iptables() {
+    ##################### PREROUTING #####################
+    iptables -t mangle -D PREROUTING -p tcp -m mark --mark 0x2333 -j TPROXY --on-ip 127.0.0.1 --on-port 60080 &>/dev/null
+    iptables -t mangle -D PREROUTING -p udp -m mark --mark 0x2333 -j TPROXY --on-ip 127.0.0.1 --on-port 60080 &>/dev/null
+
+    iptables -t mangle -D PREROUTING -p tcp -m addrtype ! --src-type LOCAL ! --dst-type LOCAL -j SSREDIR &>/dev/null
+    iptables -t mangle -D PREROUTING -p udp -m addrtype ! --src-type LOCAL ! --dst-type LOCAL -j SSREDIR &>/dev/null
+
+    ##################### OUTPUT #####################
+    iptables -t mangle -D OUTPUT -p tcp -m addrtype --src-type LOCAL ! --dst-type LOCAL -j SSREDIR &>/dev/null
+    iptables -t mangle -D OUTPUT -p udp -m addrtype --src-type LOCAL ! --dst-type LOCAL -j SSREDIR &>/dev/null
+
+    ##################### SSREDIR #####################
+    iptables -t mangle -F SSREDIR &>/dev/null
+    iptables -t mangle -X SSREDIR &>/dev/null
+}
+
+start_iproute2() {
+    ip route add local default dev lo table 100
+    ip rule  add fwmark 0x2333        table 100
+}
+
+stop_iproute2() {
+    ip rule  del   table 100 &>/dev/null
+    ip route flush table 100 &>/dev/null
+}
+
+start_resolvconf() {
+    # or nameserver 8.8.8.8, etc.
+    echo "nameserver 1.1.1.1" >/etc/resolv.conf
+}
+
+stop_resolvconf() {
+    echo "nameserver 114.114.114.114" >/etc/resolv.conf
+}
+
+start() {
+    echo "start ..."
+    start_ssredir
+    start_iptables
+    start_iproute2
+    start_resolvconf
+    echo "start end"
+}
+
+stop() {
+    echo "stop ..."
+    stop_resolvconf
+    stop_iproute2
+    stop_iptables
+    stop_ssredir
+    echo "stop end"
+}
+
+restart() {
+    stop
+    sleep 1
+    start
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        echo "usage: $0 start|stop|restart ..."
+        return 1
+    fi
+
+    for funcname in "$@"; do
+        if [ "$(type -t $funcname)" != 'function' ]; then
+            echo "'$funcname' not a shell function"
+            return 1
+        fi
+    done
+
+    for funcname in "$@"; do
+        $funcname
+    done
+    return 0
+}
+main "$@"
+```
 
 ## Security Tips
 

--- a/README.md
+++ b/README.md
@@ -398,6 +398,9 @@ you may refer to the man pages of the applications, respectively.
        [-U]                       Enable UDP relay and disable TCP relay.
                                   (not available in local mode)
 
+       [-T]                       Use tproxy instead of redirect. (for tcp)
+                                  (only available in redir mode)
+
        [-L <addr>:<port>]         Destination server address and port
                                   for local port forwarding.
                                   (only available in tunnel mode)

--- a/completions/bash/ss-redir
+++ b/completions/bash/ss-redir
@@ -1,7 +1,7 @@
 _ss_redir()
 {
     local cur prev opts ciphers
-    opts='-s -p -l -k -m -a -f -t -c -n -b -u -U -v -h --reuse-port --mtu --mptcp --key --plugin --plugin-opts --help'
+    opts='-s -p -l -k -m -a -f -t -c -n -b -u -U -T -v -h --reuse-port --mtu --mptcp --key --plugin --plugin-opts --help'
     ciphers='rc4-md5 aes-128-gcm aes-192-gcm aes-256-gcm aes-128-cfb aes-192-cfb aes-256-cfb aes-128-ctr aes-192-ctr aes-256-ctr camellia-128-cfb camellia-192-cfb camellia-256-cfb bf-cfb chacha20-ietf-poly1305 xchacha20-ietf-poly1305 salsa20 chacha20 chacha20-ietf'
     cur=${COMP_WORDS[COMP_CWORD]}
     prev="${COMP_WORDS[COMP_CWORD-1]}"

--- a/completions/zsh/_ss-redir
+++ b/completions/zsh/_ss-redir
@@ -18,6 +18,7 @@ _arguments "-h::" \
            "-u:enable udp:" \
            "-U:udp only:" \
            "-v:verbose mode:" \
+           "-T:tcp tproxy mode:" \
            "--reuse-port::" \
            "--fast-open::" \
            "--acl:acl file:_files" \

--- a/doc/shadowsocks-libev.asciidoc
+++ b/doc/shadowsocks-libev.asciidoc
@@ -122,6 +122,11 @@ Enable UDP relay and disable TCP relay.
 +
 Not available in local mode.
 
+-T::
+Use tproxy instead of redirect (for tcp).
++
+Only available in redir mode.
+
 -L <addr:port>::
 Specify destination server address and port for local port forwarding.
 +
@@ -199,6 +204,7 @@ The config file equivalent of command line options is listed as example below.
 | -u                                  | "mode": "tcp_and_udp"
 | -U                                  | "mode": "udp_only"
 | no "-u" nor "-U" options (default)  | "mode": "tcp_only"
+| -T                                  | "tcp_tproxy": true
 | (only in ss-manager's config)       | "port_password": {"1234":"PasSworD"}
 |============================================================================
 

--- a/doc/ss-redir.asciidoc
+++ b/doc/ss-redir.asciidoc
@@ -95,6 +95,9 @@ TPROXY is required in redir mode. You may need root permission.
 -U::
 Enable UDP relay and disable TCP relay.
 
+-T::
+Use tproxy instead of redirect. (for tcp)
+
 -6::
 Resovle hostname to IPv6 address first.
 

--- a/src/jconf.c
+++ b/src/jconf.c
@@ -338,6 +338,11 @@ read_jconf(const char *file)
                     value, json_boolean,
                     "invalid config file: option 'no_delay' must be a boolean");
                 conf.no_delay = value->u.boolean;
+            } else if (strcmp(name, "tcp_tproxy") == 0) {
+                check_json_value_type(
+                    value, json_boolean,
+                    "invalid config file: option 'tcp_tproxy' must be a boolean");
+                conf.tcp_tproxy = value->u.boolean;
             } else if (strcmp(name, "workdir") == 0) {
                 conf.workdir = to_string(value);
             } else if (strcmp(name, "acl") == 0) {

--- a/src/jconf.h
+++ b/src/jconf.h
@@ -82,6 +82,7 @@ typedef struct {
     int mptcp;
     int ipv6_first;
     int no_delay;
+    int tcp_tproxy;
     char *workdir;
     char *acl;
     char *manager_address;

--- a/src/utils.c
+++ b/src/utils.c
@@ -360,6 +360,10 @@ usage()
 #endif
     printf(
         "       [-U]                       Enable UDP relay and disable TCP relay.\n");
+#ifdef MODULE_REDIR
+    printf(
+        "       [-T]                       Use tproxy instead of redirect (for tcp).\n");
+#endif
 #ifdef MODULE_REMOTE
     printf(
         "       [-6]                       Resovle hostname to IPv6 address first.\n");


### PR DESCRIPTION
The current transparent proxy implementation of ss-redir is:
- tcp: redirect(dnat)
- udp: tproxy
> Now tcp tproxy also supports.

When udp transparent proxy is enabled, you need to set different rules in the mangle table (for udp tproxy) and nat table (for tcp redirect) of iptables. This is a bit troublesome and the rules are not easy to manage.

So I added tproxy incoming support for tcp, so I only need to set the rules of the iptables mangle table (tcp and udp).

In addition, in the earlier version of ip6tables (old Linux kernel), there is no nat table. But if you use the tproxy (tcp and udp) mode, you do not need to set any nat table rules, and the entire iptables rules look neater.