### PR TITLE
Remove old workaround for printf on MinGW

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -191,14 +191,8 @@ extern int use_syslog;
 
 #endif // if __ANDROID__
 
-// Workaround for "%z" in Windows printf
-#ifdef __MINGW32__
-#define SSIZE_FMT "%Id"
-#define SIZE_FMT "%Iu"
-#else
 #define SSIZE_FMT "%zd"
 #define SIZE_FMT "%zu"
-#endif
 
 #ifdef __MINGW32__
 // Override Windows built-in functions


### PR DESCRIPTION
As of latest version of GCC on MSYS2, the old workaround for printf no longer works, and will even break compilation with error:
```
In file included from udprelay.c:51:
udprelay.c: In function 'remote_recv_cb':
udprelay.c:764:18: error: format '%d' expects argument of type 'int', but argument 3 has type 'ssize_t' {aka 'long long int'} [-Werror=format=]
  764 |             LOGI("[udp] remote_recv_recvfrom fragmentation, MTU at least be: " SSIZE_FMT, r + PACKET_HEADER_SIZE);
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
utils.h:105:25: note: in definition of macro 'LOGI'
  105 |         fprintf(stdout, format "\n", ## __VA_ARGS__);        \
      |                         ^~~~~~
udprelay.c:840:18: error: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Werror=format=]
  840 |             LOGI("[udp] remote_recv_sendto fragmentation, MTU at least be: " SSIZE_FMT, buf->len + PACKET_HEADER_SIZE);
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
utils.h:105:25: note: in definition of macro 'LOGI'
  105 |         fprintf(stdout, format "\n", ## __VA_ARGS__);        \
      |                         ^~~~~~
udprelay.c: In function 'server_recv_cb':
udprelay.c:976:18: error: format '%d' expects argument of type 'int', but argument 3 has type 'ssize_t' {aka 'long long int'} [-Werror=format=]
  976 |             LOGI("[udp] server_recv_recvfrom fragmentation, MTU at least be: " SSIZE_FMT, r + PACKET_HEADER_SIZE);
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
utils.h:105:25: note: in definition of macro 'LOGI'
  105 |         fprintf(stdout, format "\n", ## __VA_ARGS__);        \
      |                         ^~~~~~
udprelay.c:1265:18: error: format '%d' expects argument of type 'int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Werror=format=]
 1265 |             LOGI("[udp] server_recv_sendto fragmentation, MTU at least be: " SSIZE_FMT, buf->len + PACKET_HEADER_SIZE);
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
utils.h:105:25: note: in definition of macro 'LOGI'
  105 |         fprintf(stdout, format "\n", ## __VA_ARGS__);        \
      |                         ^~~~~~
cc1.exe: all warnings being treated as errors

```
Current version of GCC (10.2.0) has already support `%z` in printf, so this workaround should be removed.