### PR TITLE
bump workflow actions to docker official provided

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,32 +14,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
-      - uses: crazy-max/ghaction-docker-buildx@v3
         with:
-          buildx-version: v0.4.1
+          submodules: true
 
-      - name: update submodules
-        run: git submodule update --init
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1
+        with:
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKER_USERNAME }}
 
-      - name: login docker
-        run: echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-
-      - name: build edge image
-        if: github.ref == 'refs/heads/master'
+      - name: check and set image version
+        id: prepare
         run: |
-          docker buildx build \
-            --push \
-            --platform=linux/arm64,linux/amd64 \
-            -f=docker/alpine/Dockerfile \
-            -t=${{ github.repository }}:edge \
-            .
-      - name: build version image
-        if: github.ref != 'refs/heads/master'
-        run: |
-          docker buildx build \
-            --push \
-            --platform=linux/arm64,linux/amd64 \
-            -f=docker/alpine/Dockerfile \
-            -t=${{ github.repository }}:$(echo ${{ github.ref }} | sed -E 's|refs/tags/||') \
-            .
+          case ${{ github.ref }} in
+            refs/heads/master)
+              echo ::set-output name=version::edge
+              echo ::set-output name=push::true
+            ;;
+            refs/tags/*)
+              echo ::set-output name=version::$(echo ${{ github.ref }} | sed -E 's|refs/tags/||')
+              echo ::set-output name=push::true
+            ;;
+            *)
+              echo ::set-output name=version::${{ github.sha }}
+              echo ::set-output name=push::false
+            ;;
+          esac;
+
+      - name: build & push image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/alpine/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ steps.prepare.outputs.push }}
+          tags: ${{ github.repository }}:${{ steps.prepare.outputs.version }}


### PR DESCRIPTION
https://github.com/crazy-max/ghaction-docker-buildx is ARCHIVED
need to use official Docker action instead.

`.github/dependabot.yml` is github dependences checker, which will open pr for dependency updates.
now just for github-actions.

see more https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates

build steps with the new workflow https://github.com/morlay/shadowsocks-libev/actions/runs/279598906
image published https://hub.docker.com/r/morlay/shadowsocks-libev