### PR TITLE
Fix manager not passing -i option

### DIFF
--- a/src/manager.c
+++ b/src/manager.c
@@ -186,6 +186,10 @@ construct_command_line(struct manager_ctx *manager, struct server *server)
         int len = strlen(cmd);
         snprintf(cmd + len, BUF_SIZE - len, " -u");
     }
+    if (manager->iface) {
+        int len = strlen(cmd);
+        snprintf(cmd + len, BUF_SIZE - len, " -i \"%s\"", manager->iface);
+    }
     if (server->fast_open[0] == 0 && manager->fast_open) {
         int len = strlen(cmd);
         snprintf(cmd + len, BUF_SIZE - len, " --fast-open");


### PR DESCRIPTION
#2738 
Adding those lines makes the manager to pass -i option to its servers

Recreating the issue,
the _systemctl status_ now shows the requested behaviour:

`Main PID: 16143 (ss-manager)
   CGroup: /system.slice/shadowsocks.service
           ├─16143 /usr/local/bin/ss-manager -c /home/admin/ss/shadowsocks-libev/tests/salsa20.json --manager-address /tmp/manager.sock -i eno123 --executable /usr/local/bin/ss-server
           └─16159 /usr/local/bin/ss-server --manager-address /tmp/manager.sock -f /home/admin/.shadowsocks/.shadowsocks_8001.pid -c /home/admin/.shadowsocks/.shadowsocks_8001.conf -t 60 -i eno123 -s 127.0.0.1
`