### PR TITLE
the url of libsodium 1.0.16 has been removed to the old release

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ sudo pacman -S gettext gcc autoconf libtool automake make asciidoc xmlto c-ares 
 
 # Installation of libsodium
 export LIBSODIUM_VER=1.0.16
-wget https://download.libsodium.org/libsodium/releases/libsodium-$LIBSODIUM_VER.tar.gz
+wget https://download.libsodium.org/libsodium/releases/old/libsodium-$LIBSODIUM_VER.tar.gz
 tar xvf libsodium-$LIBSODIUM_VER.tar.gz
 pushd libsodium-$LIBSODIUM_VER
 ./configure --prefix=/usr && make


### PR DESCRIPTION
libsodium 1.0.16 has been removed to the old release ,  