### PR TITLE
Fix memory leak

### DIFF
--- a/src/redir.c
+++ b/src/redir.c
@@ -1381,5 +1381,9 @@ main(int argc, char **argv)
         stop_plugin();
     }
 
+    for (i = 0; i < remote_num; i++)
+        ss_free(listen_ctx.remote_addr[i]);
+    ss_free(listen_ctx.remote_addr);
+
     return ret_val;
 }

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1427,6 +1427,10 @@ main(int argc, char **argv)
         stop_plugin();
     }
 
+    for (i = 0; i < remote_num; i++)
+        ss_free(listen_ctx.remote_addr[i]);
+    ss_free(listen_ctx.remote_addr);
+
 #ifdef __MINGW32__
     if (plugin_watcher.valid) {
         closesocket(plugin_watcher.fd);

--- a/src/udprelay.c
+++ b/src/udprelay.c
@@ -1467,6 +1467,9 @@ free_udprelay()
         ev_io_stop(loop, &server_ctx->io);
         close(server_ctx->fd);
         cache_delete(server_ctx->conn_cache, 0);
+#ifdef MODULE_LOCAL
+        free((char*) server_ctx->remote_addr);
+#endif
         ss_free(server_ctx);
         server_ctx_list[server_num] = NULL;
     }


### PR DESCRIPTION
Free memory of ```server_ctx_t``` before exiting gracefully.