### PR TITLE
Run systemd service after network is available (unit file fix)

### DIFF
--- a/debian/shadowsocks-libev.service
+++ b/debian/shadowsocks-libev.service
@@ -12,6 +12,7 @@
 Description=Shadowsocks-libev Default Server Service
 Documentation=man:shadowsocks-libev(8)
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
There is a race condition between shadowsocks-libev.service and
systemd-resolved.service after reboot/on boot. The shadowsocks
service tries to start before the dns service is started properly
and fails showing the corresponding errors in the logs.