### PR TITLE
fix check for return value of open when redirecting to null device

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -484,7 +484,7 @@ daemonize(const char *path)
     }
 
     int dev_null = open("/dev/null", O_WRONLY);
-    if (dev_null) {
+    if (dev_null > 0) {
         /* Redirect to null device  */
         dup2(dev_null, STDOUT_FILENO);
         dup2(dev_null, STDERR_FILENO);


### PR DESCRIPTION
The return value of open is -1 in case of an error (detected using Synopsys Coverity Scan)