### PR TITLE
apply memory leak fix for create_and_bind to create_server_socket

### DIFF
--- a/src/manager.c
+++ b/src/manager.c
@@ -442,7 +442,7 @@ create_and_bind(const char *host, const char *port, int protocol)
         }
     }
 
-    if (!result) {
+    if (result != NULL) {
         freeaddrinfo(result);
     }
 
@@ -837,12 +837,14 @@ create_server_socket(const char *host, const char *port)
         close(server_sock);
     }
 
+    if (result != NULL) {
+        freeaddrinfo(result);
+    }
+
     if (rp == NULL) {
         LOGE("cannot bind");
         return -1;
     }
-
-    freeaddrinfo(result);
 
     return server_sock;
 }


### PR DESCRIPTION
freeaddrinfo fix in create_and_bind needs to be applied in create_server_socket (detected using Synopsys Coverity Scan)