### PR TITLE
Add git submodule to the build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ sudo snap install shadowsocks-libev --edge
 
 * * *
 
+### Initialise the build environment
+
+This repository uses submodules, so you should pull them before you start, using:
+
+```bash
+git submodule update --init --recursive
+```
+
 ### Pre-build configure guide
 
 For a complete list of available configure-time option,


### PR DESCRIPTION
This confused me, and looking at the issues, it has confused other people as well. [1](https://github.com/shadowsocks/shadowsocks-libev/issues/2758) [2](https://github.com/shadowsocks/shadowsocks-libev/issues/2844)

I'm not sure if we can automate it though, e.g. in `autogen.sh`. Because some people might want to build with a modified version of the libraries.

Perhaps we could automatically fetch the submodules IF we see they are empty...

Anyway, for now, we can at least document this step.