### PR TITLE
fix: being able to use empty DNS_ADDRS with docker image

### DIFF
--- a/docker/alpine/entrypoint.sh
+++ b/docker/alpine/entrypoint.sh
@@ -8,12 +8,15 @@ if [[ -f "/var/run/secrets/$PASSWORD_SECRET" ]]; then
     PASSWORD=$(cat "/var/run/secrets/$PASSWORD_SECRET")
 fi
 
+if [[ ! -z "$DNS_ADDRS" ]]; then
+    ARGS="-d $DNS_ADDRS $ARGS"
+fi
+
 exec ss-server \
       -s $SERVER_ADDR \
       -p $SERVER_PORT \
       -k ${PASSWORD:-$(hostname)} \
       -m $METHOD \
       -t $TIMEOUT \
-      -d $DNS_ADDRS \
       -u \
       $ARGS


### PR DESCRIPTION
Hi! First of all, thank you for maintaining this amazing tool.

# Issue

Overriding the image's default `$DNS_ADDRS` with an empty string still adds the `-d` option to the command.

# Solution

Make sure that we only add the `-d` option if `$DNS_ADDRS` is defined and not empty.