### PR TITLE
Fix build on MinGW

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,7 @@ dnl Add library for mingw
 case $host in
   *-mingw*)
     CFLAGS="$CFLAGS -mno-ms-bitfields"
-    LIBS="$LIBS -lws2_32"
+    LIBS="$LIBS -lws2_32 -liphlpapi"
     ;;
   *-cygwin*)
     CFLAGS="$CFLAGS -mno-ms-bitfields"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,7 +117,7 @@ list(APPEND DEPS
         )
 
 if (MINGW)
-list(APPEND DEPS ws2_32)
+list(APPEND DEPS ws2_32 iphlpapi)
 add_compile_definitions(CARES_STATICLIB PCRE_STATIC)
 endif ()
 endif ()


### PR DESCRIPTION
Recently builds on MinGW start to fail with undefined symbol errors:

```
[ 49%] Linking C executable ../bin/ss-server.exe
C:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/11.2.0/../../../../i686-w64-mingw32/bin/ld.exe: C:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/11.2.0/../../../../lib\libcares.a(ares__addrinfo_localhost.c.obj):(.text+0x1fe): undefined reference to `GetUnicastIpAddressTable@8'
C:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/11.2.0/../../../../i686-w64-mingw32/bin/ld.exe: C:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/11.2.0/../../../../lib\libcares.a(ares__addrinfo_localhost.c.obj):(.text+0x360): undefined reference to `FreeMibTable@4'
C:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/11.2.0/../../../../i686-w64-mingw32/bin/ld.exe: C:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/11.2.0/../../../../lib\libcares.a(ares__addrinfo_localhost.c.obj):(.text+0x44d): undefined reference to `FreeMibTable@4'
C:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/11.2.0/../../../../i686-w64-mingw32/bin/ld.exe: C:/msys64/mingw32/bin/../lib/gcc/i686-w64-mingw32/11.2.0/../../../../lib\libcares.a(ares__addrinfo_localhost.c.obj):(.text+0x491): undefined reference to `FreeMibTable@4'
collect2.exe: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/ss-server.dir/build.make:364: bin/ss-server.exe] Error 1
make[1]: *** [CMakeFiles/Makefile2:308: src/CMakeFiles/ss-server.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```