### PR TITLE
fix maybe-uninitialized errors

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -168,7 +168,7 @@ create_and_bind(const char *addr, const char *port)
 {
     struct addrinfo hints;
     struct addrinfo *result, *rp;
-    int s, listen_sock;
+    int s, listen_sock = -1;
 
     memset(&hints, 0, sizeof(struct addrinfo));
     hints.ai_family   = AF_UNSPEC;   /* Return IPv4 and IPv6 choices */

--- a/src/redir.c
+++ b/src/redir.c
@@ -147,7 +147,7 @@ create_and_bind(const char *addr, const char *port)
 {
     struct addrinfo hints;
     struct addrinfo *result, *rp;
-    int s, listen_sock;
+    int s, listen_sock = -1;
 
     memset(&hints, 0, sizeof(struct addrinfo));
     hints.ai_family   = AF_UNSPEC;   /* Return IPv4 and IPv6 choices */

--- a/src/server.c
+++ b/src/server.c
@@ -550,7 +550,7 @@ create_and_bind(const char *host, const char *port, int mptcp)
 {
     struct addrinfo hints;
     struct addrinfo *result, *rp, *ipv4v6bindall;
-    int s, listen_sock;
+    int s, listen_sock = -1;
 
     memset(&hints, 0, sizeof(struct addrinfo));
     hints.ai_family   = AF_UNSPEC;               /* Return IPv4 and IPv6 choices */

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -129,7 +129,7 @@ create_and_bind(const char *addr, const char *port)
 {
     struct addrinfo hints;
     struct addrinfo *result, *rp;
-    int s, listen_sock;
+    int s, listen_sock = -1;
 
     memset(&hints, 0, sizeof(struct addrinfo));
     hints.ai_family   = AF_UNSPEC;   /* Return IPv4 and IPv6 choices */

--- a/src/udprelay.c
+++ b/src/udprelay.c
@@ -446,7 +446,7 @@ create_server_socket(const char *host, const char *port)
 {
     struct addrinfo hints;
     struct addrinfo *result, *rp, *ipv4v6bindall;
-    int s, server_sock;
+    int s, server_sock = -1;
 
     memset(&hints, 0, sizeof(struct addrinfo));
     hints.ai_family   = AF_UNSPEC;               /* Return IPv4 and IPv6 choices */


### PR DESCRIPTION
Set `{listen,server}_sock` to `-1` when needed as already done in `src/manager.c` by commit ecf1fcc84594b09ed2d61e3677cd8e62bd897ccb to avoid the following build failure:

```
local.c: In function 'create_and_bind':
local.c:218:12: error: 'listen_sock' may be used uninitialized in this function [-Werror=maybe-uninitialized]
  218 |     return listen_sock;
      |            ^~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/27471a878ff52a972ac087d534e44fb0c50808f6

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>