### PR TITLE
Redir UDP send back sockets should always be IPv6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ doc/*.html
 
 # Visual Studio Code
 .vscode/*
+.devcontainer/*


### PR DESCRIPTION
ref shadowsocks/shadowsocks-rust#855

When receiving UDP packets from remote servers, Redir will have to
create transparent sockets to bind() on those target addresses and then
relay data back to the local client. Target addresses may be IPv4 or
IPv6 addresses, so we may have to create that transprent sockets based
on the target addresses' family.

The most simpliest and easiest way is to always create IPv6 sockets and
converts IPv4 binding addresses and peer addresses to IPv4-mapped-IPv6.