### PR TITLE
Detect kernel support for MPTCP at runtime

### DIFF
--- a/src/jconf.c
+++ b/src/jconf.c
@@ -340,7 +340,7 @@ read_jconf(const char *file)
             } else if (strcmp(name, "mptcp") == 0) {
                 check_json_value_type(value, json_boolean,
                                       "invalid config file: option 'mptcp' must be a boolean");
-                conf.mptcp = value->u.boolean;
+                conf.mptcp = get_mptcp(value->u.boolean);
             } else if (strcmp(name, "ipv6_first") == 0) {
                 check_json_value_type(value, json_boolean,
                                       "invalid config file: option 'ipv6_first' must be a boolean");

--- a/src/netutils.h
+++ b/src/netutils.h
@@ -60,13 +60,18 @@ typedef struct {
     char *port;
 } ss_addr_t;
 
+// Be compatible with older libc.
 #ifndef IPPROTO_MPTCP
-/* MPTCP_ENABLED setsockopt values for kernel 4 & 3, best behaviour to be independant of kernel version is to test from newest to the latest values */
+#define IPPROTO_MPTCP 262
+#endif
+
+/* MPTCP_ENABLED setsockopt values for out-of-tree kernel 4 & 3, best behaviour
+ * to be independent of kernel version is to test from newest to latest values.
+ */
 #ifndef MPTCP_ENABLED
 static const char mptcp_enabled_values[] = { 42, 26, 0 };
 #else
 static const char mptcp_enabled_values[] = { MPTCP_ENABLED, 0 };
-#endif
 #endif
 
 #ifndef UPDATE_INTERVAL

--- a/src/redir.c
+++ b/src/redir.c
@@ -771,11 +771,9 @@ accept_cb(EV_P_ ev_io *w, int revents)
     struct sockaddr *remote_addr = listener->remote_addr[index];
 
     int protocol = IPPROTO_TCP;
-#ifdef IPPROTO_MPTCP
-    if (listener->mptcp > 0) {
-	protocol = IPPROTO_MPTCP;
+    if (listener->mptcp < 0) {
+        protocol = IPPROTO_MPTCP; // Enable upstream MPTCP
     }
-#endif
     int remotefd = socket(remote_addr->sa_family, SOCK_STREAM, protocol);
     if (remotefd == -1) {
         ERROR("socket");
@@ -814,12 +812,11 @@ accept_cb(EV_P_ ev_io *w, int revents)
 #endif
     }
 
-#ifndef IPPROTO_MPTCP
-    // Enable MPTCP
+    // Enable out-of-tree MPTCP
     if (listener->mptcp > 1) {
         int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
         if (err == -1) {
-            ERROR("failed to enable multipath TCP");
+            ERROR("failed to enable out-of-tree multipath TCP");
         }
     } else if (listener->mptcp == 1) {
         int i = 0;
@@ -831,10 +828,9 @@ accept_cb(EV_P_ ev_io *w, int revents)
             i++;
         }
         if (listener->mptcp == 0) {
-            ERROR("failed to enable multipath TCP");
+            ERROR("failed to enable out-of-tree multipath TCP");
         }
     }
-#endif
 
     if (tcp_outgoing_sndbuf > 0) {
         setsockopt(remotefd, SOL_SOCKET, SO_SNDBUF, &tcp_outgoing_sndbuf, sizeof(int));
@@ -959,8 +955,9 @@ main(int argc, char **argv)
             LOGI("set MTU to %d", mtu);
             break;
         case GETOPT_VAL_MPTCP:
-            mptcp = 1;
-            LOGI("enable multipath TCP");
+            mptcp = get_mptcp(1);
+            if (mptcp)
+                LOGI("enable multipath TCP (%s)", mptcp > 0 ? "out-of-tree" : "upstream");
             break;
         case GETOPT_VAL_NODELAY:
             no_delay = 1;

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -737,11 +737,9 @@ accept_cb(EV_P_ ev_io *w, int revents)
     struct sockaddr *remote_addr = listener->remote_addr[index];
 
     int protocol = IPPROTO_TCP;
-#ifdef IPPROTO_MPTCP
-    if (listener->mptcp > 0) {
-        protocol = IPPROTO_MPTCP;
+    if (listener->mptcp < 0) {
+        protocol = IPPROTO_MPTCP; // Enable upstream MPTCP
     }
-#endif
     int remotefd = socket(remote_addr->sa_family, SOCK_STREAM, protocol);
     if (remotefd == -1) {
         ERROR("socket");
@@ -773,11 +771,11 @@ accept_cb(EV_P_ ev_io *w, int revents)
     setsockopt(remotefd, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof(opt));
 #endif
 
-#ifndef IPPROTO_MPTCP
+    // Enable out-of-tree MPTCP
     if (listener->mptcp > 1) {
         int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
         if (err == -1) {
-            ERROR("failed to enable multipath TCP");
+            ERROR("failed to enable out-of-tree multipath TCP");
         }
     } else if (listener->mptcp == 1) {
         int i = 0;
@@ -789,10 +787,9 @@ accept_cb(EV_P_ ev_io *w, int revents)
             i++;
         }
         if (listener->mptcp == 0) {
-            ERROR("failed to enable multipath TCP");
+            ERROR("failed to enable out-of-tree multipath TCP");
         }
     }
-#endif
 
     if (tcp_outgoing_sndbuf > 0) {
         setsockopt(remotefd, SOL_SOCKET, SO_SNDBUF, &tcp_outgoing_sndbuf, sizeof(int));
@@ -956,8 +953,9 @@ main(int argc, char **argv)
             LOGI("set MTU to %d", mtu);
             break;
         case GETOPT_VAL_MPTCP:
-            mptcp = 1;
-            LOGI("enable multipath TCP");
+            mptcp = get_mptcp(1);
+            if (mptcp)
+                LOGI("enable multipath TCP (%s)", mptcp > 0 ? "out-of-tree" : "upstream");
             break;
         case GETOPT_VAL_NODELAY:
             no_delay = 1;

--- a/src/utils.c
+++ b/src/utils.c
@@ -578,3 +578,20 @@ load16_be(const void *s)
     return ((uint16_t)in[0] << 8)
            | ((uint16_t)in[1]);
 }
+
+int
+get_mptcp(int enable)
+{
+    const char oldpath[] = "/proc/sys/net/mptcp/mptcp_enabled";
+
+    if (enable) {
+        // Check if kernel has out-of-tree MPTCP support.
+        if (access(oldpath, F_OK) != -1)
+            return 1;
+
+        // Otherwise, just use IPPROTO_MPTCP.
+        return -1;
+    }
+
+    return 0;
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -250,5 +250,6 @@ void *ss_realloc(void *ptr, size_t new_size);
 int ss_is_ipv6addr(const char *addr);
 char *get_default_conf(void);
 uint16_t load16_be(const void *s);
+int get_mptcp(int enable);
 
 #endif // _UTILS_H


### PR DESCRIPTION
Since 1630764b02bbcbf0980d8080ea6ee8fd9b2cabf0 shadowsocks-libev has gained the ability to make use of upstream MPTCP if available. Let's improve on that a bit, and figure out the way to enable MPTCP at runtime, rather than at build time.

Difference between MPTCP kernels is explained at https://github.com/multipath-tcp/mptcp_net-next/wiki#upstream-vs-out-of-tree-implementations

Procfs path difference are seemingly explained in mptcpd tests, at https://github.com/intel/mptcpd/blob/master/tests/test-mptcpwrap

So use IPPROTO_MPTCP on negative `mptcp` variable value, and tolerate absence of that constant at build time.