### PR TITLE
Fix rpm build for fedora 36

### DIFF
--- a/rpm/SPECS/shadowsocks-libev.spec.in
+++ b/rpm/SPECS/shadowsocks-libev.spec.in
@@ -14,6 +14,9 @@
 %global use_systemd 0
 %endif
 
+# https://fedoraproject.org/wiki/Changes/RemoveLaFiles
+%global __brp_remove_la_files %nil
+
 Name:		    @NAME@
 Version:	    @VERSION@
 Release:	    @RELEASE@%{?dist}


### PR DESCRIPTION
Building rpm on fedora 36 fails with ENOENT on libshadowsocks-libev.la. This happens because .la files now get automatically removed from buildroot. Assuming someone needs that .la file, opt out of the change, as described in "How To Test" section of the linked page.