### PR TITLE
Add submodules to git safe.directory for .copr build

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -17,4 +17,7 @@ endif
 
 srpm: deps
 	git config --global --add safe.directory $(TOP_DIR)
+	git config --global --add safe.directory $(TOP_DIR)/libbloom
+	git config --global --add safe.directory $(TOP_DIR)/libcork
+	git config --global --add safe.directory $(TOP_DIR)/libipset
 	$(RPM_DIR)/genrpm.sh -o $(outdir)


### PR DESCRIPTION
Copr build for fedora 36 fails because submodule dirs are not in git safe.directory variable. Just add them explicitly, without fancy stuff like "git submodule foreach".