### PR TITLE
Update

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,21 +1,17 @@
-#
-# Dockerfile for shadowsocks-libev
-#
+FROM alpine:3.16
+LABEL maintainer="kev <noreply@datageek.info>, Sah <contact@leesah.name>, vndroid <waveworkshop@outlook.com>"
 
-FROM alpine
-LABEL maintainer="kev <noreply@datageek.info>, Sah <contact@leesah.name>"
-
-ENV SERVER_ADDR 0.0.0.0
-ENV SERVER_PORT 8388
+ENV SERVER_ADDR=0.0.0.0
+ENV SERVER_PORT=8388
 ENV PASSWORD=
-ENV METHOD      aes-256-gcm
-ENV TIMEOUT     300
-ENV DNS_ADDRS    8.8.8.8,8.8.4.4
-ENV TZ UTC
+ENV METHOD=aes-256-gcm
+ENV TIMEOUT=300
+ENV DNS_ADDRS="8.8.8.8,8.8.4.4"
+ENV TZ=UTC
 ENV ARGS=
 
 COPY . /tmp/repo
-RUN set -ex \
+RUN set -x \
  # Build environment setup
  && apk add --no-cache --virtual .build-deps \
       autoconf \
@@ -33,8 +29,10 @@ RUN set -ex \
  && cd /tmp/repo \
  && ./autogen.sh \
  && ./configure --prefix=/usr --disable-documentation \
+ && make -j$(getconf _NPROCESSORS_ONLN) \
  && make install \
  && ls /usr/bin/ss-* | xargs -n1 setcap cap_net_bind_service+ep \
+ && strip $(ls /usr/local/bin | grep -Ev 'ss-nat') \
  && apk del .build-deps \
  # Runtime dependencies setup
  && apk add --no-cache \
@@ -46,8 +44,11 @@ RUN set -ex \
       | sort -u) \
  && rm -rf /tmp/repo
 
-USER nobody
+COPY ./docker/alpine/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]
 
-COPY ./docker/alpine/entrypoint.sh /entrypoint.sh
+EXPOSE 8388
 
-CMD /entrypoint.sh
+STOPSIGNAL SIGINT
+
+CMD ["ss-server"]

--- a/docker/alpine/entrypoint.sh
+++ b/docker/alpine/entrypoint.sh
@@ -1,22 +1,31 @@
 #!/bin/sh
+# vim:sw=4:ts=4:et
 
-if [[ -f "$PASSWORD_FILE" ]]; then
-    PASSWORD=$(cat "$PASSWORD_FILE")
+set -e
+
+if [ "$1" = "ss-server" ]; then
+    COREVER=$(uname -r | grep -Eo '[0-9].[0-9]+' | sed -n '1,1p')
+    CMV=$(echo $COREVER | awk -F '.' '{print $1}')
+    CSV=$(echo $COREVER | awk -F '.' '{print $2}')
+
+    if [[ -f "$PASSWORD_FILE" ]]; then
+        PASSWORD=$(cat "$PASSWORD_FILE")
+    fi
+    
+    if [[ -f "/var/run/secrets/$PASSWORD_SECRET" ]]; then
+        PASSWORD=$(cat "/var/run/secrets/$PASSWORD_SECRET")
+    fi
+    
+    if [[ ! -z "$DNS_ADDRS" ]]; then
+        DNS="-d $DNS_ADDRS"
+    fi
+
+    if [ $(echo "$CMV >= 3" | bc) ]; then
+        if [ $(echo "$CSV > 7" | bc) ]; then
+        TFO='--fast-open'
+        fi
+    fi 
+    RT_ARGS="-s $SERVER_ADDR -p $SERVER_PORT -k ${PASSWORD:-$(hostname)} -m $METHOD -a nobody -t $TIMEOUT -u $DNS $TFO $ARGS"
 fi
 
-if [[ -f "/var/run/secrets/$PASSWORD_SECRET" ]]; then
-    PASSWORD=$(cat "/var/run/secrets/$PASSWORD_SECRET")
-fi
-
-if [[ ! -z "$DNS_ADDRS" ]]; then
-    ARGS="-d $DNS_ADDRS $ARGS"
-fi
-
-exec ss-server \
-      -s $SERVER_ADDR \
-      -p $SERVER_PORT \
-      -k ${PASSWORD:-$(hostname)} \
-      -m $METHOD \
-      -t $TIMEOUT \
-      -u \
-      $ARGS
+exec $@ $RT_ARGS


### PR DESCRIPTION
- Solve the problem that nobody users do not have root after entering the container
- Execute strip after compilation
- Support multi-threaded compilation

The configuration file is referenced from [shadowsocks-libev Dockerfile](https://github.com/vndroid/docker-library/tree/main/shadowsocks-libev). remove some ENV (eg: COMMIT_ID). Made some changes for compatibility.

Using this Dockerfile, the container can be entered. I made an example image https://hub.docker.com/r/vndroid/shadowsocks-libev

Contrast:

- Origin

```
$ docker container run --rm -it shadowsocks/shadowsocks-libev:edge /bin/sh
~ $ apk add --no-cache git
ERROR: Unable to lock database: Permission denied
ERROR: Failed to open apk database: Permission denied
```

- New

```
$ docker container run --rm -it vndroid/shadowsocks-libev:alpine /bin/sh
/ # apk add --no-cache git
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
(1/6) Installing brotli-libs (1.0.9-r6)
(2/6) Installing nghttp2-libs (1.47.0-r0)
(3/6) Installing libcurl (7.83.1-r1)
(4/6) Installing expat (2.4.8-r0)
(5/6) Installing pcre2 (10.40-r0)
(6/6) Installing git (2.36.1-r0)
Executing busybox-1.35.0-r13.trigger
OK: 25 MiB in 32 packages
```