### PR TITLE
update MbedTLS dependency link and add Debian / Ubuntu apt pkg-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ sudo ldconfig
 
 # Installation of MbedTLS
 export MBEDTLS_VER=2.6.0
-wget https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/mbedtls-2.6.0.tar.gz
+wget https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/mbedtls-$MBEDTLS_VER.tar.gz
 tar xvf mbedtls-$MBEDTLS_VER.tar.gz
 pushd mbedtls-$MBEDTLS_VER
 make SHARED=1 CFLAGS="-O2 -fPIC"

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ For some of the distributions, you might install build dependencies like this:
 ```bash
 # Installation of basic build dependencies
 ## Debian / Ubuntu
-sudo apt-get install --no-install-recommends gettext build-essential autoconf libtool libpcre3-dev asciidoc xmlto libev-dev libc-ares-dev automake libmbedtls-dev libsodium-dev
+sudo apt-get install --no-install-recommends gettext build-essential autoconf libtool libpcre3-dev asciidoc xmlto libev-dev libc-ares-dev automake libmbedtls-dev libsodium-dev pkg-config
 ## CentOS / Fedora / RHEL
 sudo yum install gettext gcc autoconf libtool automake make asciidoc xmlto c-ares-devel libev-devel
 ## Arch
@@ -243,8 +243,8 @@ sudo ldconfig
 
 # Installation of MbedTLS
 export MBEDTLS_VER=2.6.0
-wget https://tls.mbed.org/download/mbedtls-$MBEDTLS_VER-gpl.tgz
-tar xvf mbedtls-$MBEDTLS_VER-gpl.tgz
+wget https://github.com/Mbed-TLS/mbedtls/archive/refs/tags/mbedtls-2.6.0.tar.gz
+tar xvf mbedtls-$MBEDTLS_VER.tar.gz
 pushd mbedtls-$MBEDTLS_VER
 make SHARED=1 CFLAGS="-O2 -fPIC"
 sudo make DESTDIR=/usr install


### PR DESCRIPTION
I tried to build from source on Ubuntu 22.04 LTS today and found `https://tls.mbed.org/download/` link is broken. Also I ran into errors when executing `./autogen.sh`, `error: possibly undefined macro: AC_MSG_ERROR`. `apt install pkg-config` fixes the error and built successfully.