### PR TITLE
Deprecate load16_be() function in favor to ntohs() function.

### DIFF
--- a/src/aead.c
+++ b/src/aead.c
@@ -596,7 +596,7 @@ aead_chunk_decrypt(cipher_ctx_t *ctx, uint8_t *p, uint8_t *c, uint8_t *n,
         return CRYPTO_ERROR;
     assert(*plen == CHUNK_SIZE_LEN);
 
-    mlen = load16_be(len_buf);
+    mlen = ntohs(*(uint16_t*)len_buf);
     mlen = mlen & CHUNK_SIZE_MASK;
 
     if (mlen == 0)

--- a/src/local.c
+++ b/src/local.c
@@ -382,7 +382,7 @@ server_handshake(EV_P_ ev_io *w, buffer_t *buf)
         abuf->len += in_addr_len + 2;
 
         if (acl || verbose) {
-            uint16_t p = load16_be(buf->data + request_len + in_addr_len);
+            uint16_t p = ntohs(*(uint16_t*)(buf->data + request_len + in_addr_len));
             if (!inet_ntop(AF_INET, (const void *)(buf->data + request_len),
                            ip, INET_ADDRSTRLEN)) {
                 LOGI("inet_ntop(AF_INET): %s", strerror(errno));
@@ -400,7 +400,7 @@ server_handshake(EV_P_ ev_io *w, buffer_t *buf)
         abuf->len += name_len + 2;
 
         if (acl || verbose) {
-            uint16_t p = load16_be(buf->data + request_len + 1 + name_len);
+            uint16_t p = ntohs(*(uint16_t*)(buf->data + request_len + 1 + name_len));
             memcpy(host, buf->data + request_len + 1, name_len);
             host[name_len] = '\0';
             sprintf(port, "%d", p);
@@ -414,7 +414,7 @@ server_handshake(EV_P_ ev_io *w, buffer_t *buf)
         abuf->len += in6_addr_len + 2;
 
         if (acl || verbose) {
-            uint16_t p = load16_be(buf->data + request_len + in6_addr_len);
+            uint16_t p = ntohs(*(uint16_t*)(buf->data + request_len + in6_addr_len));
             if (!inet_ntop(AF_INET6, (const void *)(buf->data + request_len),
                            ip, INET6_ADDRSTRLEN)) {
                 LOGI("inet_ntop(AF_INET6): %s", strerror(errno));

--- a/src/server.c
+++ b/src/server.c
@@ -1129,7 +1129,7 @@ server_recv_cb(EV_P_ ev_io *w, int revents)
             return;
         }
 
-        port = ntohs(load16_be(server->buf->data + offset));
+        port = *(uint16_t*)(server->buf->data + offset);
 
         offset += 2;
 

--- a/src/udprelay.c
+++ b/src/udprelay.c
@@ -316,7 +316,7 @@ parse_udprelay_header(const char *buf, const size_t buf_len,
     }
 
     if (port != NULL) {
-        sprintf(port, "%d", load16_be(buf + offset));
+        sprintf(port, "%d", ntohs(*(uint16_t*)(buf + offset)));
     }
     offset += 2;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -571,14 +571,6 @@ get_default_conf(void)
 #endif
 }
 
-uint16_t
-load16_be(const void *s)
-{
-    const uint8_t *in = (const uint8_t *)s;
-    return ((uint16_t)in[0] << 8)
-           | ((uint16_t)in[1]);
-}
-
 int
 get_mptcp(int enable)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -249,7 +249,6 @@ void *ss_realloc(void *ptr, size_t new_size);
 
 int ss_is_ipv6addr(const char *addr);
 char *get_default_conf(void);
-uint16_t load16_be(const void *s);
 int get_mptcp(int enable);
 
 #endif // _UTILS_H


### PR DESCRIPTION
**load16_be()** function is inefficient and basically does the same work as **ntohs()**.