### PR TITLE
Fix the issue where the program exits when the operating system does not support TCP_FASTOPEN_CONNECT.

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -714,7 +714,7 @@ server_stream(EV_P_ ev_io *w, buffer_t *buf)
             int optval = 1;
             if (setsockopt(remote->fd, IPPROTO_TCP, TCP_FASTOPEN_CONNECT,
                            (void *)&optval, sizeof(optval)) < 0)
-                FATAL("failed to set TCP_FASTOPEN_CONNECT");
+                LOGW("failed to set TCP_FASTOPEN_CONNECT");
             s = connect(remote->fd, (struct sockaddr *)&(remote->addr), remote->addr_len);
 #else
             FATAL("fast open is not enabled in this build");

--- a/src/redir.c
+++ b/src/redir.c
@@ -551,7 +551,7 @@ remote_send_cb(EV_P_ ev_io *w, int revents)
             int optval = 1;
             if (setsockopt(remote->fd, IPPROTO_TCP, TCP_FASTOPEN_CONNECT,
                            (void *)&optval, sizeof(optval)) < 0)
-                FATAL("failed to set TCP_FASTOPEN_CONNECT");
+                LOGW("failed to set TCP_FASTOPEN_CONNECT");
             s = connect(remote->fd, remote->addr, get_sockaddr_len(remote->addr));
             if (s == 0)
                 s = send(remote->fd, remote->buf->data, remote->buf->len, 0);

--- a/src/server.c
+++ b/src/server.c
@@ -789,7 +789,7 @@ connect_to_remote(EV_P_ struct addrinfo *res,
         int optval = 1;
         if (setsockopt(sockfd, IPPROTO_TCP, TCP_FASTOPEN_CONNECT,
                        (void *)&optval, sizeof(optval)) < 0)
-            FATAL("failed to set TCP_FASTOPEN_CONNECT");
+            LOGW("failed to set TCP_FASTOPEN_CONNECT");
         s = connect(sockfd, res->ai_addr, res->ai_addrlen);
 #elif defined(CONNECT_DATA_IDEMPOTENT)
         struct sockaddr_in sa;

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -534,7 +534,7 @@ remote_send_cb(EV_P_ ev_io *w, int revents)
             int optval = 1;
             if (setsockopt(remote->fd, IPPROTO_TCP, TCP_FASTOPEN_CONNECT,
                            (void *)&optval, sizeof(optval)) < 0)
-                FATAL("failed to set TCP_FASTOPEN_CONNECT");
+                LOGW("failed to set TCP_FASTOPEN_CONNECT");
             s = connect(remote->fd, remote->addr, get_sockaddr_len(remote->addr));
             if (s == 0)
                 s = send(remote->fd, remote->buf->data, remote->buf->len, 0);

--- a/src/utils.h
+++ b/src/utils.h
@@ -40,6 +40,9 @@
 #define LOGI(...)                                                \
     ((void)__android_log_print(ANDROID_LOG_DEBUG, "shadowsocks", \
                                __VA_ARGS__))
+#define LOGW(...)                                                \
+    ((void)__android_log_print(ANDROID_LOG_WARN, "shadowsocks",  \
+                               __VA_ARGS__))
 #define LOGE(...)                                                \
     ((void)__android_log_print(ANDROID_LOG_ERROR, "shadowsocks", \
                                __VA_ARGS__))
@@ -74,6 +77,17 @@ extern FILE *logfile;
             fflush(logfile); }                                                   \
     }                                                                            \
     while (0)
+#define LOGW(format, ...)                                           \
+    do {                                                            \
+        if (logfile != NULL) {                                      \
+            time_t now = time(NULL);                                \
+            char timestr[20];                                       \
+            strftime(timestr, 20, TIME_FORMAT, localtime(&now));    \
+            fprintf(logfile, " %s WARNNING: " format "\n", timestr, \
+                    ## __VA_ARGS__);                                \
+            fflush(logfile); }                                      \
+    }                                                               \
+    while (0)
 #define LOGE(format, ...)                                        \
     do {                                                         \
         if (logfile != NULL) {                                   \
@@ -105,6 +119,19 @@ extern FILE *logfile;
         fprintf(stdout, format "\n", ## __VA_ARGS__);        \
         fflush(stdout);                                      \
     }                                                        \
+    while (0)
+
+#define LOGW(format, ...)                                     \
+    do {                                                      \
+        time_t now = time(NULL);                              \
+        char timestr[20];                                     \
+        strftime(timestr, 20, TIME_FORMAT, localtime(&now));  \
+        ss_color_error();                                     \
+        fprintf(stderr, " %s WARNNING: ", timestr);           \
+        ss_color_reset();                                     \
+        fprintf(stderr, format "\n", ## __VA_ARGS__);         \
+        fflush(stderr);                                       \
+    }                                                         \
     while (0)
 
 #define LOGE(format, ...)                                     \
@@ -163,6 +190,26 @@ extern int use_syslog;
             }                                                                    \
         }                                                                        \
     }                                                                            \
+    while (0)
+
+#define LOGW(format, ...)                                                            \
+    do {                                                                             \
+        if (use_syslog) {                                                            \
+            syslog(LOG_ERR, format, ## __VA_ARGS__);                                 \
+        } else {                                                                     \
+            time_t now = time(NULL);                                                 \
+            char timestr[20];                                                        \
+            strftime(timestr, 20, TIME_FORMAT, localtime(&now));                     \
+            if (use_tty) {                                                           \
+                fprintf(stderr, "\e[01;35m %s WARNNING: \e[0m" format "\n", timestr, \
+                        ## __VA_ARGS__);                                             \
+                fflush(stderr);                                                      \
+            } else {                                                                 \
+                fprintf(stderr, " %s WARNNING: " format "\n", timestr,               \
+                        ## __VA_ARGS__);                                             \
+                fflush(stderr);                                                      \
+            }                                                                        \
+        } }                                                                          \
     while (0)
 
 #define LOGE(format, ...)                                                         \


### PR DESCRIPTION
If the operating system does not support TCP_FASTOPEN_CONNECT or in a container environment, the service should still function normally, albeit with lower performance.