### PR TITLE
[ss-manager] Fall back to /tmp if workdir is /

### DIFF
--- a/src/manager.c
+++ b/src/manager.c
@@ -1123,7 +1123,8 @@ main(int argc, char **argv)
     if (workdir == NULL || strlen(workdir) == 0) {
         workdir = pw->pw_dir;
         // If home dir is still not defined or set to nologin/nonexistent, fall back to /tmp
-        if (workdir == NULL || strlen(workdir) == 0 || strstr(workdir, "nologin") || strstr(workdir, "nonexistent")) {
+        if (workdir == NULL || strlen(workdir) == 0 || strstr(workdir, "nologin") || 
+            strstr(workdir, "nonexistent") || strcmp(workdir, "/") == 0) {
             workdir = "/tmp";
         }
 


### PR DESCRIPTION
I want to try using `ss-manager` to replace `ss-server`. I updated the `ExecStart` option, the config file located `/lib/systemd/system/shadowsocks-libev.service`.

```
...
DynamicUser=true
ExecStart=/usr/bin/ss-manager -c $CONFFILE $DAEMON_ARGS
...
```

Then I restarted the service, I got the following log.

```
Nov 23 11:59:23 eve systemd[1]: Started Shadowsocks-libev Default Server Service.
Nov 23 11:59:23 eve ss-manager[483697]:  2023-11-23 11:59:23 INFO: using tcp fast open
Nov 23 11:59:23 eve ss-manager[483697]:  2023-11-23 11:59:23 INFO: working directory points to //.shadowsocks
Nov 23 11:59:23 eve ss-manager[483697]:  2023-11-23 11:59:23 ERROR: mkdir: Read-only file system
Nov 23 11:59:23 eve ss-manager[483697]:  2023-11-23 11:59:23 ERROR: unable to create working directory
Nov 23 11:59:23 eve systemd[1]: shadowsocks-libev.service: Main process exited, code=exited, status=255/EXCEPTION
Nov 23 11:59:23 eve systemd[1]: shadowsocks-libev.service: Failed with result 'exit-code'.
```


I noticed that `DynamicUser` is used in the default systemd config, which may be why the user's workdir is '/', I thought maybe it could ignore / and use /tmp instead.