### PR TITLE
support cipher none

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -131,6 +131,42 @@ entropy_check(void)
 #endif
 }
 
+#ifndef ATTR_UNUSED
+#define ATTR_UNUSED __attribute__((unused))
+#endif
+
+static int none_encrypt_all(ATTR_UNUSED buffer_t *a, ATTR_UNUSED cipher_t *b, ATTR_UNUSED size_t c) {
+    return CRYPTO_OK;
+}
+
+static int none_decrypt_all(ATTR_UNUSED buffer_t *a, ATTR_UNUSED cipher_t *b, ATTR_UNUSED size_t c) {
+    return CRYPTO_OK;
+}
+
+static int none_encrypt(ATTR_UNUSED buffer_t *a, ATTR_UNUSED cipher_ctx_t *b, ATTR_UNUSED size_t c) {
+    return CRYPTO_OK;
+}
+
+static int none_decrypt(ATTR_UNUSED buffer_t *a, ATTR_UNUSED cipher_ctx_t *b, ATTR_UNUSED size_t c) {
+    return CRYPTO_OK;
+}
+
+static void none_ctx_init(ATTR_UNUSED cipher_t *a, ATTR_UNUSED cipher_ctx_t *b, ATTR_UNUSED int c) {
+}
+
+static void none_ctx_release(ATTR_UNUSED cipher_ctx_t *a) {
+}
+
+static crypto_t none_crypt = {
+        .cipher      = NULL,
+        .encrypt_all = &none_encrypt_all,
+        .decrypt_all = &none_decrypt_all,
+        .encrypt     = &none_encrypt,
+        .decrypt     = &none_decrypt,
+        .ctx_init    = &none_ctx_init,
+        .ctx_release = &none_ctx_release,
+};
+
 crypto_t *
 crypto_init(const char *password, const char *key, const char *method)
 {
@@ -150,6 +186,10 @@ crypto_init(const char *password, const char *key, const char *method)
 #endif
 
     if (method != NULL) {
+        if (strcmp(method, "none") == 0) {
+            return &none_crypt;
+        }
+
         for (i = 0; i < STREAM_CIPHER_NUM; i++)
             if (strcmp(method, supported_stream_ciphers[i]) == 0) {
                 m = i;

--- a/src/local.c
+++ b/src/local.c
@@ -1709,7 +1709,7 @@ main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 #endif
-    if (!password && !key) {
+    if (!password && !key && strcmp(method, "none")) {
         fprintf(stderr, "both password and key are NULL\n");
         exit(EXIT_FAILURE);
     }

--- a/src/redir.c
+++ b/src/redir.c
@@ -1150,7 +1150,7 @@ main(int argc, char **argv)
     }
 
     if (remote_num == 0 || remote_port == NULL || local_port == NULL
-        || (password == NULL && key == NULL)) {
+        || (password == NULL && key == NULL && strcmp(method, "none"))) {
         usage();
         exit(EXIT_FAILURE);
     }

--- a/src/server.c
+++ b/src/server.c
@@ -2100,7 +2100,7 @@ main(int argc, char **argv)
     }
 
     if (server_num == 0 || server_port == NULL
-        || (password == NULL && key == NULL)) {
+        || (password == NULL && key == NULL && strcmp(method, "none"))) {
         usage();
         exit(EXIT_FAILURE);
     }

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1151,7 +1151,7 @@ main(int argc, char **argv)
     }
 
     if (remote_num == 0 || remote_port == NULL || tunnel_addr_str == NULL
-        || local_port == NULL || (password == NULL && key == NULL)) {
+        || local_port == NULL || (password == NULL && key == NULL && strcmp(method, "none"))) {
         usage();
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
Although this project is bux-fix-only, I'd like to add cipher `none`.

And it's history:
- 2016-10-26, shadowsocks-rust add cipher `dummy` for debugging: https://github.com/shadowsocks/shadowsocks-rust/commit/f302298c91e57f709a2f191e8535d40d63f690ec
- 2017-05-03, shadowsocks-libev received cipher `plain` pr: https://github.com/shadowsocks/shadowsocks-libev/pull/1506 @madeye choose not to merge
- 2018-01-20, shadowsocks-rust renamed `dummy` to `plain` in https://github.com/shadowsocks/shadowsocks-rust/commit/5c89e61a2e6cd4887c9b6238b97cab0dbbd810f1
- 2020-02-27, shadowsocks-android support cipher `plain`: https://github.com/shadowsocks/shadowsocks-android/commit/c138232c376d73a5ece2e8a2e0ddf12ddca4cb8e by @madeye
- 2020-05-03, start discussing of the cipher name, `none` or `plain`: https://github.com/shadowsocks/shadowsocks-org/issues/161
- 2020-05-07, shadowsocks-rust make `none` as a alias of `plain`: https://github.com/shadowsocks/shadowsocks-rust/commit/74d3c61f8e30ae3e96088b9ac948662241852675
- 2020-05-08, shadowsocks-android rename cipher `plain` to `none`: https://github.com/shadowsocks/shadowsocks-android/commit/d81638a129f9cce75caaf073924f80a4a3752774 by @madeye
- 2020-09-15, shadowsocks-libev released 3.3.5 https://github.com/shadowsocks/shadowsocks-libev/releases/tag/v3.3.5 by @madeye
