### PR TITLE
Fix build with mbedtls3.6

### DIFF
--- a/m4/mbedtls.m4
+++ b/m4/mbedtls.m4
@@ -31,7 +31,12 @@ AC_DEFUN([ss_MBEDTLS],
   AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM(
       [[
+#include <mbedtls/version.h>
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+#include <mbedtls/mbedtls_config.h>
+#else
 #include <mbedtls/config.h>
+#endif
       ]],
       [[
 #ifndef MBEDTLS_CIPHER_MODE_CFB
@@ -48,7 +53,12 @@ AC_DEFUN([ss_MBEDTLS],
   AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM(
       [[
+#include <mbedtls/version.h>
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+#include <mbedtls/mbedtls_config.h>
+#else
 #include <mbedtls/config.h>
+#endif
       ]],
       [[
 #ifndef MBEDTLS_ARC4_C
@@ -64,7 +74,12 @@ AC_DEFUN([ss_MBEDTLS],
   AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM(
       [[
+#include <mbedtls/version.h>
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+#include <mbedtls/mbedtls_config.h>
+#else
 #include <mbedtls/config.h>
+#endif
       ]],
       [[
 #ifndef MBEDTLS_BLOWFISH_C
@@ -80,7 +95,12 @@ AC_DEFUN([ss_MBEDTLS],
   AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM(
       [[
+#include <mbedtls/version.h>
+#if MBEDTLS_VERSION_NUMBER >= 0x03000000
+#include <mbedtls/mbedtls_config.h>
+#else
 #include <mbedtls/config.h>
+#endif
       ]],
       [[
 #ifndef MBEDTLS_CAMELLIA_C

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -103,7 +103,7 @@ crypto_md5(const unsigned char *d, size_t n, unsigned char *md)
     if (md == NULL) {
         md = m;
     }
-#if MBEDTLS_VERSION_NUMBER >= 0x02070000
+#if MBEDTLS_VERSION_NUMBER < 0x03000000 && MBEDTLS_VERSION_NUMBER >= 0x02070000
     if (mbedtls_md5_ret(d, n, md) != 0)
         FATAL("Failed to calculate MD5");
 #else

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -97,7 +97,6 @@ typedef struct buffer {
 typedef struct {
     int method;
     int skey;
-    cipher_kt_t *info;
     size_t nonce_len;
     size_t key_len;
     size_t tag_len;


### PR DESCRIPTION
MbedTLS have released its new stable version 3.6 since Mar 28 this year. Many linux distributions are switching to it now. Shadowsocks-libev build fails with mbedtls3.0+ version. https://github.com/shadowsocks/shadowsocks-libev/issues/2868
This issue stops distributions such as debian from migrating to mbedtls3.6.
Since this is a bug-fix only port, I hope to be able to fix this problem upstream.
Some of the reasons for the changes can be found here: https://github.com/fw876/helloworld/issues/1504
@madeye 