### PR TITLE
Fix failed assertion with Mbed TLS 3

### DIFF
--- a/src/aead.c
+++ b/src/aead.c
@@ -180,11 +180,11 @@ aead_cipher_encrypt(cipher_ctx_t *cipher_ctx,
 #if MBEDTLS_VERSION_NUMBER < 0x03000000
         err = mbedtls_cipher_auth_encrypt(cipher_ctx->evp, n, nlen, ad, adlen,
                                           m, mlen, c, clen, c + mlen, tlen);
+        *clen += tlen;
 #else
         err = mbedtls_cipher_auth_encrypt_ext(cipher_ctx->evp, n, nlen, ad, adlen,
                                               m, mlen, c, mlen + tlen, clen, tlen);
 #endif
-        *clen += tlen;
         break;
     case CHACHA20POLY1305IETF:
         err = crypto_aead_chacha20poly1305_ietf_encrypt(c, &long_clen, m, mlen,


### PR DESCRIPTION
When compiled against Mbed TLS 3 (on my environment, Fedora's [`mbedtls-3.6.5-1.fc42.aarch64`](https://koji.fedoraproject.org/koji/buildinfo?buildID=2844713)), the client program reports a failed assertion:
```
ss-local: aead.c:521: aead_chunk_encrypt: Assertion `clen == CHUNK_SIZE_LEN + tlen' failed.
```

This appears to have been introduced by #2999. Indeed, the resource referenced there (fw876/helloworld#1504) provides a patch that contains an identical change; it might be an overlook when porting. I have tested the change with MSan and UBSan.

Ref. [`mbedtls_cipher_auth_encrypt_ext()` documentation](https://mbed-tls.readthedocs.io/projects/api/en/v3.6.5/api/file/cipher_8h/#cipher_8h_1a64ea7a5500f054d1d60a22369d171eea): "*the tag will be appended to the ciphertext*", so the output length already includes the tag and no longer needs another `+= tlen`.

I hope this helps.