### PR TITLE
Fix unbounded buffer growth in aead_decrypt chunk reassembly

### DIFF
--- a/src/aead.c
+++ b/src/aead.c
@@ -650,9 +650,12 @@ aead_decrypt(buffer_t *ciphertext, cipher_ctx_t *cipher_ctx, size_t capacity)
         chunk->idx = 0;
         ciphertext->len = 0;
     } else {
-        brealloc(chunk,
-                 chunk->idx + chunk->len + ciphertext->len, capacity);
-        memcpy(chunk->data + chunk->idx + chunk->len,
+        if (chunk->idx > 0) {
+            memmove(chunk->data, chunk->data + chunk->idx, chunk->len);
+            chunk->idx = 0;
+        }
+        brealloc(chunk, chunk->len + ciphertext->len, capacity);
+        memcpy(chunk->data + chunk->len,
                ciphertext->data, ciphertext->len);
         chunk->len += ciphertext->len;
     }


### PR DESCRIPTION
## Summary

- The idx-tracking optimization in `aead_decrypt` (from 31731ba) skipped `memmove` when partial AEAD chunks spanned multiple calls, but never compacted the dead space before `idx`
- This caused the chunk buffer to grow proportionally to total data transferred (~10 MB growth per 10 MB), tripping the stress test memory leak threshold on macOS CI
- Fix: compact residual data to the front when appending new ciphertext, keeping the buffer bounded

Server RSS before/after (10 MB transfer):

| Cipher | Before fix | After fix |
|---|---|---|
| aes-128-gcm | 8.4 → 18.7 MB (+10.3 MB) | 2.5 → 3.1 MB (+0.6 MB) |
| aes-256-gcm | 8.2 → 14.4 MB (+6.2 MB) | 2.5 → 3.2 MB (+0.7 MB) |
| chacha20-ietf-poly1305 | 8.1 → 18.5 MB (+10.3 MB) | 2.5 → 3.2 MB (+0.7 MB) |

## Test plan

- [x] Unit tests pass (`ctest --output-on-failure`)
- [x] Stress test passes locally (`python3 tests/stress_test.py --bin build/shared/bin/ --size 10`)
- [x] CI passes on ubuntu-latest and macos-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)