### PR TITLE
Fix static c-ares detection for c-ares >= 1.27

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build
         run: |
           mkdir -p build && cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Release -DWITH_STATIC=OFF
+          cmake .. -DCMAKE_BUILD_TYPE=Release
           make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)
 
       - name: Unit tests

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,7 +105,7 @@ find_library(LIBMBEDTLS libmbedtls.a)
 find_library(LIBMBEDCRYPTO libmbedcrypto.a HINTS ${_MBEDTLS_LIB_DIR} NO_DEFAULT_PATH)
 find_library(LIBMBEDCRYPTO libmbedcrypto.a)
 find_library(LIBEV libev.a)
-find_library(LIBUDNS libcares.a)
+find_library(LIBUDNS NAMES libcares.a libcares_static.a)
 find_library(LIBPCRE2 libpcre2-8.a)
 
 # Dependencies we need for static and shared


### PR DESCRIPTION
## Summary
- c-ares >= 1.27 (as shipped in Ubuntu 24.04) renamed the static library from `libcares.a` to `libcares_static.a`
- The `find_library(LIBUDNS libcares.a)` call fails on these newer systems, breaking the static build
- Use `find_library(LIBUDNS NAMES libcares.a libcares_static.a)` to search for both names, maintaining backward compatibility with older distros

Fixes #3024

## Test plan
- [ ] Verify static build succeeds on Ubuntu 24.04 (c-ares >= 1.27, `libcares_static.a`)
- [ ] Verify static build still succeeds on Ubuntu 22.04 (c-ares 1.18, `libcares.a`)
- [ ] CI passes on both ubuntu-latest and macos-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)