### PR TITLE
Bump alpine to v3.19

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.19
 LABEL maintainer="kev <noreply@datageek.info>, Sah <contact@leesah.name>, vndroid <waveworkshop@outlook.com>"
 
 ENV SERVER_ADDR=0.0.0.0
@@ -31,7 +31,7 @@ RUN set -x \
  && make install \
  && cd /usr/local/bin \
  && ls /usr/local/bin/ss-* | xargs -n1 setcap cap_net_bind_service+ep \
- && strip $(ls /usr/local/bin | grep -Ev 'ss-nat') \
+ && strip $(ls /usr/local/bin | grep -Ev 'ss-nat' | grep -Ev 'ss-setup') \
  && apk del .build-deps \
  # Runtime dependencies setup
  && apk add --no-cache \


### PR DESCRIPTION
- update base image to v3.19
- fix "strip: ss-setup: file format not recognized." 