### PR TITLE
Fix CMake Warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 set(PROJECT_NAME shadowsocks-libev)
 set(RELEASE_DATE 2026-02-09)

--- a/cmake/FindPCRE2.cmake
+++ b/cmake/FindPCRE2.cmake
@@ -5,9 +5,9 @@
 #   PCRE2_INCLUDE_DIRS
 #   PCRE2_LIBRARIES
 
-include(FindPkgConfig)
+find_package(PkgConfig QUIET)
 
-if(PKG_CONFIG_FOUND)
+if(PkgConfig_FOUND)
     pkg_check_modules(_PCRE2 QUIET libpcre2-8)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,8 @@ function(ss_add_test name sources libs)
     add_executable(${name} ${sources})
     target_compile_definitions(${name} PRIVATE -DHAVE_CONFIG_H)
     target_link_libraries(${name} ${libs})
+    # Keep assertions enabled for tests even in Release builds.
+    target_compile_options(${name} PRIVATE -UNDEBUG)
     add_test(NAME ${name} COMMAND ${name})
 endfunction()
 


### PR DESCRIPTION
Such as:

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

```

and CMake:

```
CMake Warning (dev) at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:430 (message):
  The package name passed to find_package_handle_standard_args() (PkgConfig)
  does not match the name of the calling package (PCRE2).  This can lead to
  problems in calling code that expects find_package() result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPkgConfig.cmake:108 (find_package_handle_standard_args)
  cmake/FindPCRE2.cmake:8 (include)
  CMakeLists.txt:50 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

and test warning:

```
/srv/shadowsocks-libev/tests/test_base64.c: In function 'test_encode_decode':
/srv/shadowsocks-libev/tests/test_base64.c:19:9: warning: unused variable 'decoded_len' [-Wunused-variable]
   19 |     int decoded_len = base64_decode(decoded, encoded, sizeof(decoded));
      |         ^~~~~~~~~~~
/srv/shadowsocks-libev/tests/test_base64.c:15:11: warning: unused variable 'ret' [-Wunused-variable]
   15 |     char *ret = base64_encode(encoded, sizeof(encoded), input, 5);
      |           ^~~
/srv/shadowsocks-libev/tests/test_base64.c: In function 'test_empty_input':
/srv/shadowsocks-libev/tests/test_base64.c:28:11: warning: unused variable 'ret' [-Wunused-variable]
   28 |     char *ret = base64_encode(encoded, sizeof(encoded), (const uint8_t *)"", 0);
      |           ^~~
/srv/shadowsocks-libev/tests/test_base64.c: In function 'test_single_byte':
/srv/shadowsocks-libev/tests/test_base64.c:43:9: warning: unused variable 'decoded_len' [-Wunused-variable]
   43 |     int decoded_len = base64_decode(decoded, encoded, sizeof(decoded));
      |         ^~~~~~~~~~~
/srv/shadowsocks-libev/tests/test_base64.c:40:11: warning: unused variable 'ret' [-Wunused-variable]
   40 |     char *ret = base64_encode(encoded, sizeof(encoded), input, 1);
      |           ^~~
/srv/shadowsocks-libev/tests/test_base64.c: In function 'test_two_bytes':
/srv/shadowsocks-libev/tests/test_base64.c:58:9: warning: unused variable 'decoded_len' [-Wunused-variable]
   58 |     int decoded_len = base64_decode(decoded, encoded, sizeof(decoded));
      |         ^~~~~~~~~~~
/srv/shadowsocks-libev/tests/test_base64.c:55:11: warning: unused variable 'ret' [-Wunused-variable]
   55 |     char *ret = base64_encode(encoded, sizeof(encoded), input, 2);
      |           ^~~
/srv/shadowsocks-libev/tests/test_base64.c: In function 'test_three_bytes':
/srv/shadowsocks-libev/tests/test_base64.c:74:9: warning: unused variable 'decoded_len' [-Wunused-variable]
   74 |     int decoded_len = base64_decode(decoded, encoded, sizeof(decoded));
      |         ^~~~~~~~~~~
/srv/shadowsocks-libev/tests/test_base64.c:71:11: warning: unused variable 'ret' [-Wunused-variable]
   71 |     char *ret = base64_encode(encoded, sizeof(encoded), input, 3);
      |           ^~~
/srv/shadowsocks-libev/tests/test_base64.c: In function 'test_roundtrip_binary':
/srv/shadowsocks-libev/tests/test_base64.c:92:9: warning: unused variable 'decoded_len' [-Wunused-variable]
   92 |     int decoded_len = base64_decode(decoded, encoded, sizeof(decoded));
      |         ^~~~~~~~~~~
/srv/shadowsocks-libev/tests/test_base64.c:89:11: warning: unused variable 'ret' [-Wunused-variable]
   89 |     char *ret = base64_encode(encoded, sizeof(encoded), input, 17);
      |           ^~~
/srv/shadowsocks-libev/tests/test_base64.c: In function 'test_invalid_chars':
/srv/shadowsocks-libev/tests/test_base64.c:101:9: warning: unused variable 'decoded_len' [-Wunused-variable]
  101 |     int decoded_len = base64_decode((uint8_t[4]){}, "!!!!", 4);
      |         ^~~~~~~~~~~
```