### PR TITLE
Fix truncated UDP and JSON bounds checks

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -304,7 +304,7 @@ json_value * json_parse_ex (json_settings * settings,
                   case 't':  string_add ('\t');  break;
                   case 'u':
 
-                    if (end - state.ptr < 4 || 
+                    if (end - state.ptr <= 4 ||
                         (uc_b1 = hex_value (*++ state.ptr)) == 0xFF ||
                         (uc_b2 = hex_value (*++ state.ptr)) == 0xFF ||
                         (uc_b3 = hex_value (*++ state.ptr)) == 0xFF ||
@@ -321,7 +321,7 @@ json_value * json_parse_ex (json_settings * settings,
                     if ((uchar & 0xF800) == 0xD800) {
                         json_uchar uchar2;
                         
-                        if (end - state.ptr < 6 || (*++ state.ptr) != '\\' || (*++ state.ptr) != 'u' ||
+                        if (end - state.ptr <= 6 || (*++ state.ptr) != '\\' || (*++ state.ptr) != 'u' ||
                             (uc_b1 = hex_value (*++ state.ptr)) == 0xFF ||
                             (uc_b2 = hex_value (*++ state.ptr)) == 0xFF ||
                             (uc_b3 = hex_value (*++ state.ptr)) == 0xFF ||
@@ -600,7 +600,7 @@ json_value * json_parse_ex (json_settings * settings,
 
                      case 't':
 
-                        if ((end - state.ptr) < 3 || *(++ state.ptr) != 'r' ||
+                        if ((end - state.ptr) <= 3 || *(++ state.ptr) != 'r' ||
                             *(++ state.ptr) != 'u' || *(++ state.ptr) != 'e')
                         {
                            goto e_unknown_value;
@@ -616,7 +616,7 @@ json_value * json_parse_ex (json_settings * settings,
 
                      case 'f':
 
-                        if ((end - state.ptr) < 4 || *(++ state.ptr) != 'a' ||
+                        if ((end - state.ptr) <= 4 || *(++ state.ptr) != 'a' ||
                             *(++ state.ptr) != 'l' || *(++ state.ptr) != 's' ||
                             *(++ state.ptr) != 'e')
                         {
@@ -631,7 +631,7 @@ json_value * json_parse_ex (json_settings * settings,
 
                      case 'n':
 
-                        if ((end - state.ptr) < 3 || *(++ state.ptr) != 'u' ||
+                        if ((end - state.ptr) <= 3 || *(++ state.ptr) != 'u' ||
                             *(++ state.ptr) != 'l' || *(++ state.ptr) != 'l')
                         {
                            goto e_unknown_value;
@@ -1032,4 +1032,3 @@ void json_value_free (json_value * value)
    settings.mem_free = default_free;
    json_value_free_ex (&settings, value);
 }
-

--- a/src/udprelay.c
+++ b/src/udprelay.c
@@ -245,6 +245,10 @@ static int
 parse_udprelay_header(const char *buf, const size_t buf_len,
                       char *host, char *port, struct sockaddr_storage *storage)
 {
+    if (buf_len < 1) {
+        return 0;
+    }
+
     const uint8_t atyp = *(uint8_t *)buf;
     int offset         = 1;
 
@@ -267,6 +271,9 @@ parse_udprelay_header(const char *buf, const size_t buf_len,
         }
     } else if ((atyp & ADDRTYPE_MASK) == 3) {
         // Domain name
+        if (buf_len < offset + 1) {
+            return 0;
+        }
         uint8_t name_len = *(uint8_t *)(buf + offset);
         if (name_len + 4 <= buf_len) {
             if (storage != NULL) {

--- a/tests/test_json.c
+++ b/tests/test_json.c
@@ -95,6 +95,26 @@ test_parse_invalid(void)
 }
 
 static void
+test_parse_truncated_escape_sequences(void)
+{
+    /* Four bytes remain after 'u', but the fourth hex read would hit EOF. */
+    const char *truncated_unicode_escape = "\"\\uB2D";
+    assert(json_parse(truncated_unicode_escape, strlen(truncated_unicode_escape)) == NULL);
+
+    /* Six bytes remain after the high surrogate, but the sixth read would hit EOF. */
+    const char *truncated_surrogate_pair = "\"\\udfff\\ufff";
+    assert(json_parse(truncated_surrogate_pair, strlen(truncated_surrogate_pair)) == NULL);
+}
+
+static void
+test_parse_truncated_literals(void)
+{
+    assert(json_parse("tru", 3) == NULL);
+    assert(json_parse("fals", 4) == NULL);
+    assert(json_parse("nul", 3) == NULL);
+}
+
+static void
 test_parse_empty_object(void)
 {
     const char *json_str = "{}";
@@ -124,6 +144,8 @@ main(void)
     test_parse_nested();
     test_parse_types();
     test_parse_invalid();
+    test_parse_truncated_escape_sequences();
+    test_parse_truncated_literals();
     test_parse_empty_object();
     test_parse_empty_array();
     return 0;


### PR DESCRIPTION
## Summary

- Fix off-by-one JSON parser length guards for truncated Unicode escapes, surrogate pairs, and literal values.
- Return early from UDP relay header parsing before reading a missing domain length byte.
- Add JSON regression coverage for the truncated parser inputs.

## Why

The open fuzzing reports describe one-byte out-of-bounds reads on malformed UDP and JSON inputs. The affected code checked the remaining buffer length too loosely before pre-increment reads.

Closes #3035
Closes #3036
Closes #3037

## Validation

- `cc -fsanitize=address -g -I src tests/test_json.c src/json.c -lm -o /tmp/shadowsocks-libev-test-json`
- `/tmp/shadowsocks-libev-test-json`
- `git diff --check`

Full CMake configure was not run locally because the checkout host is missing mbedTLS.
